### PR TITLE
Add ability to add juttle engine to an express app.

### DIFF
--- a/lib/express-routes.js
+++ b/lib/express-routes.js
@@ -1,0 +1,98 @@
+'use strict';
+var _ = require('underscore');
+var express = require('express');
+var bodyParser = require('body-parser');
+var jobs = require('./job-handlers');
+var paths = require('./path-handlers');
+var prepares = require('./prepare-handlers');
+var logger = require('log4js').getLogger('juttle-express-router');
+
+var read_config = require('juttle/lib/config/read-config');
+var JuttleEngineErrors = require('./errors');
+
+var API_PREFIX = '/api/v0';
+
+function default_error_handler(err, req, res, next) {
+    logger.debug('got error "' + err.message + '"');
+
+    // Errors from bodyParser.json() might appear here. Transform
+    // them into the error formats we expect.
+    if (err.message.startsWith('Unexpected token')) {
+        err = JuttleEngineErrors.bundleError(err.message, err.body);
+    } else if (! JuttleEngineErrors.is_juttled_error(err)) {
+        // This error isn't one of the standard errors in
+        // JuttledErrors. Wrap the error in an UnknownError.
+        err = JuttleEngineErrors.unknownError(err);
+    }
+
+    res.status(err.status).send(err);
+}
+
+function add_routes(app, options) {
+
+    let config = read_config(_.pick(options, 'config_path'));
+
+    let max_saved_messages = 1024;
+    let delayed_job_cleanup = 10000;
+
+    if (_.has(config, 'juttled')) {
+        if (_.has(config.juttled, 'max_saved_messages')) {
+            max_saved_messages = config.juttled.max_saved_messages;
+        }
+
+        if (_.has(config.juttled, 'delayed_job_cleanup')) {
+            delayed_job_cleanup = config.juttled.delayed_job_cleanup;
+        }
+    }
+
+    jobs.init({max_saved_messages: max_saved_messages,
+               delayed_job_cleanup: delayed_job_cleanup,
+               config_path: options.config_path,
+               root_directory: options.root_directory});
+    paths.init({root_directory: options.root_directory});
+
+    // Create an express router to handle all the non-websocket
+    // routes. For the websocket routes, we need to add them directly
+    // to the app.
+    let router = express.Router(_.pick(options,
+                                       'caseSensitive',
+                                       'mergeParams',
+                                       'strict'));
+
+    router.get('/jobs',
+               jobs.list_all_jobs);
+    router.get('/jobs/:job_id',
+               jobs.list_job);
+    router.delete('/jobs/:job_id',
+                  jobs.delete_job);
+    router.post('/jobs',
+                bodyParser.json(), jobs.create_job);
+    router.get('/observers/',
+               jobs.list_observers);
+
+    router.get('/paths/*',
+               bodyParser.json(), paths.get_path);
+    router.get('/directory',
+               bodyParser.json(), paths.get_dir);
+
+    router.post('/prepare',
+                bodyParser.json(), prepares.get_inputs);
+
+    router.use(default_error_handler);
+
+    app.use(API_PREFIX, router);
+
+    app.ws(API_PREFIX + '/jobs/:job_id',
+              jobs.subscribe_job);
+    app.ws(API_PREFIX + '/observers/:observer_id',
+              jobs.subscribe_observer);
+    app.ws(API_PREFIX + '/rendezvous/:topic',
+              paths.rendezvous_topic);
+
+    return router;
+}
+
+module.exports = {
+    add_routes: add_routes
+};
+

--- a/lib/juttle-engine.js
+++ b/lib/juttle-engine.js
@@ -1,45 +1,25 @@
-var Base = require('extendable-base');
-var _ = require('underscore');
+'use strict';
 var express = require('express');
 var expressWs = require('express-ws');
-var bodyParser = require('body-parser');
-var jobs = require('./job-handlers');
-var paths = require('./path-handlers');
-var prepares = require('./prepare-handlers');
 var logger = require('log4js').getLogger('juttle-engine');
 
 var read_config = require('juttle/lib/config/read-config');
 var Juttle = require('juttle/lib/runtime').Juttle;
-var JuttledErrors = require('./errors');
+var JuttleExpressRoutes = require('./express-routes');
 
-var API_PREFIX = '/api/v0';
+class JuttleEngine {
 
-var JuttleEngine = Base.extend({
+    constructor(options) {
 
-    initialize: function(options) {
-        var config = read_config(options);
+        let config = read_config(options);
         Juttle.adapters.configure(config.adapters);
-        var self = this;
 
-        self._config_path = options.config_path;
         this._app = express();
         expressWs(this._app);
 
         this._app.disable('x-powered-by');
 
-        this._root_directory = options.root_directory;
-        this._max_saved_messages = 1024;
-        this._delayed_job_cleanup = 10000;
-
-        if (_.has(config, 'juttled')) {
-            if (_.has(config.juttled, 'max_saved_messages')) {
-                this._max_saved_messages = config.juttled.max_saved_messages;
-            }
-
-            if (_.has(config.juttled, 'delayed_job_cleanup')) {
-                this._delayed_job_cleanup = config.juttled.delayed_job_cleanup;
-            }
-        }
+        JuttleExpressRoutes.add_routes(this._app, options);
 
         // add cors headers, allow ALL origins
         this._app.use(function (req, res, next) {
@@ -52,73 +32,15 @@ var JuttleEngine = Base.extend({
             next();
         });
 
-        this.initRoutes();
-
-        this._server = this._app.listen(options.port, function() {
-            logger.info('Juttle engine listening at http://localhost:' + options.port + ' with root directory:' + self._root_directory);
+        this._server = this._app.listen(options.port, () => {
+            logger.info('Juttle engine listening at http://localhost:' + options.port + ' with root directory:' + options.root_directory);
         });
-    },
-
-    initRoutes: function() {
-
-        jobs.init({max_saved_messages: this._max_saved_messages,
-                   delayed_job_cleanup: this._delayed_job_cleanup,
-                   config_path: this._config_path,
-                   root_directory: this._root_directory});
-        paths.init({root_directory: this._root_directory});
-
-        this._app.get(API_PREFIX + '/jobs',
-                      jobs.list_all_jobs);
-        this._app.get(API_PREFIX + '/jobs/:job_id',
-                      jobs.list_job);
-        this._app.delete(API_PREFIX + '/jobs/:job_id',
-                         jobs.delete_job);
-        this._app.post(API_PREFIX + '/jobs',
-                      bodyParser.json(), jobs.create_job);
-        this._app.ws(API_PREFIX + '/jobs/:job_id',
-                    jobs.subscribe_job);
-        this._app.ws(API_PREFIX + '/observers/:observer_id',
-                    jobs.subscribe_observer);
-        this._app.get(API_PREFIX + '/observers/',
-                    jobs.list_observers);
-
-        this._app.get(API_PREFIX + '/paths/*',
-                     bodyParser.json(), paths.get_path);
-        this._app.get(API_PREFIX + '/directory',
-                      bodyParser.json(), paths.get_dir);
-
-        this._app.post(API_PREFIX + '/prepare',
-                      bodyParser.json(), prepares.get_inputs);
-
-        this._app.ws('/rendezvous/:topic',
-                    paths.rendezvous_topic);
-
-        this._app.use(this.default_error_handler.bind(this));
-
-    },
-
-    default_error_handler: function(err, req, res, next) {
-        logger.debug('got error "' + err.message + '"');
-
-        // Errors from bodyParser.json() might appear here. Transform
-        // them into the error formats we expect.
-        if (err.message.startsWith('Unexpected token')) {
-            err = JuttledErrors.bundleError(err.message, err.body);
-        } else if (! JuttledErrors.is_juttled_error(err)) {
-            // This error isn't one of the standard errors in
-            // JuttledErrors. Wrap the error in an UnknownError.
-            err = JuttledErrors.unknownError(err);
-        }
-
-        res.status(err.status).send(err);
-    },
-
-    stop: function() {
-        var self = this;
-
-        self._server.close();
     }
 
-});
+    stop() {
+        this._server.close();
+    }
+
+}
 
 module.exports = JuttleEngine;

--- a/lib/juttle-engine.js
+++ b/lib/juttle-engine.js
@@ -1,36 +1,26 @@
 'use strict';
 var express = require('express');
-var expressWs = require('express-ws');
 var logger = require('log4js').getLogger('juttle-engine');
 
 var read_config = require('juttle/lib/config/read-config');
 var Juttle = require('juttle/lib/runtime').Juttle;
-var JuttleExpressRoutes = require('./express-routes');
+var add_routes = require('./routes');
 
 class JuttleEngine {
 
     constructor(options) {
 
         let config = read_config(options);
+
+        // Add the config as an option so add_routes doesn't have to read it again.
+        options.config = config;
         Juttle.adapters.configure(config.adapters);
 
         this._app = express();
-        expressWs(this._app);
 
         this._app.disable('x-powered-by');
 
-        JuttleExpressRoutes.add_routes(this._app, options);
-
-        // add cors headers, allow ALL origins
-        this._app.use(function (req, res, next) {
-
-            res.setHeader('Access-Control-Allow-Origin', '*');
-            res.setHeader('Access-Control-Allow-Methods', 'GET, POST, OPTIONS, PUT, PATCH, DELETE');
-            res.setHeader('Access-Control-Allow-Headers', 'X-Requested-With,content-type');
-
-            // Pass to next layer of middleware
-            next();
-        });
+        add_routes(this._app, options);
 
         this._server = this._app.listen(options.port, () => {
             logger.info('Juttle engine listening at http://localhost:' + options.port + ' with root directory:' + options.root_directory);

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -1,13 +1,13 @@
 'use strict';
 var _ = require('underscore');
 var express = require('express');
+var expressWs = require('express-ws');
 var bodyParser = require('body-parser');
 var jobs = require('./job-handlers');
 var paths = require('./path-handlers');
 var prepares = require('./prepare-handlers');
 var logger = require('log4js').getLogger('juttle-express-router');
 
-var read_config = require('juttle/lib/config/read-config');
 var JuttleEngineErrors = require('./errors');
 
 var API_PREFIX = '/api/v0';
@@ -30,18 +30,16 @@ function default_error_handler(err, req, res, next) {
 
 function add_routes(app, options) {
 
-    let config = read_config(_.pick(options, 'config_path'));
-
     let max_saved_messages = 1024;
     let delayed_job_cleanup = 10000;
 
-    if (_.has(config, 'juttled')) {
-        if (_.has(config.juttled, 'max_saved_messages')) {
-            max_saved_messages = config.juttled.max_saved_messages;
+    if (_.has(options.config, 'juttled')) {
+        if (_.has(options.config.juttled, 'max_saved_messages')) {
+            max_saved_messages = options.config.juttled.max_saved_messages;
         }
 
-        if (_.has(config.juttled, 'delayed_job_cleanup')) {
-            delayed_job_cleanup = config.juttled.delayed_job_cleanup;
+        if (_.has(options.config.juttled, 'delayed_job_cleanup')) {
+            delayed_job_cleanup = options.config.juttled.delayed_job_cleanup;
         }
     }
 
@@ -52,12 +50,8 @@ function add_routes(app, options) {
     paths.init({root_directory: options.root_directory});
 
     // Create an express router to handle all the non-websocket
-    // routes. For the websocket routes, we need to add them directly
-    // to the app.
-    let router = express.Router(_.pick(options,
-                                       'caseSensitive',
-                                       'mergeParams',
-                                       'strict'));
+    // routes.
+    let router = express.Router();
 
     router.get('/jobs',
                jobs.list_all_jobs);
@@ -82,6 +76,15 @@ function add_routes(app, options) {
 
     app.use(API_PREFIX, router);
 
+    // For the websocket routes, we need to add them directly to the
+    // app, as the package we use (express-ws) doesn't support adding
+    // websocket-based paths to routers (see
+    // https://github.com/HenningM/express-ws/issues/8).
+
+    if (! app.ws) {
+        expressWs(app);
+    }
+
     app.ws(API_PREFIX + '/jobs/:job_id',
               jobs.subscribe_job);
     app.ws(API_PREFIX + '/observers/:observer_id',
@@ -92,7 +95,5 @@ function add_routes(app, options) {
     return router;
 }
 
-module.exports = {
-    add_routes: add_routes
-};
+module.exports = add_routes;
 


### PR DESCRIPTION
Split juttle-engine.js into two pieces. All the express route handlers
are now in express-routes.js. The main function takes an express app
and options and attaches all the routes to the app. We use an express
router to hold the middleware (bodyParser), error
handling (default_error_handler), and all of the http-based routes.

However, the package we use for websocket handling (express-ws)
doesn't support adding endpoints to routers, only apps. For that
reason, the main function adds to an app instead of returning a
standalone router.

juttle-engine.js now just creates the express app, uses express-routes
to add the routes to the app, and starts the server.

Also switch to ES6 classes instead of extendable-base.

@demmer 