### PR TITLE
Update to juttle 0.4.0.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ services:
 
 before_install:
     - export CXX="g++-4.8"
-    - npm install juttle@^0.3.0
+    - npm install juttle@^0.4.0
 
 node_js:
     - '4.2'

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "ws": "^0.4.31"
   },
   "peerDependencies": {
-    "juttle": "^0.3.0"
+    "juttle": "^0.4.0"
   },
   "devDependencies": {
     "bluebird-retry": "^0.5.3",

--- a/test/juttle-engine.spec.js
+++ b/test/juttle-engine.spec.js
@@ -331,7 +331,7 @@ describe('Juttle Engine Tests', function() {
                                 },
                                 'module': 'no-such-juttle.juttle'
                             },
-                            'message': 'Error: could not find module "no-such-juttle.juttle"'
+                            'message': 'could not find module "no-such-juttle.juttle"'
                         }
                     }
                 });
@@ -735,7 +735,7 @@ describe('Juttle Engine Tests', function() {
                                 },
                                 module: 'no-such-module.juttle'
                             },
-                            message: 'Error: could not find module "no-such-module.juttle"'
+                            message: 'could not find module "no-such-module.juttle"'
                         }
                     }
                 });
@@ -777,7 +777,7 @@ describe('Juttle Engine Tests', function() {
                     errors: [],
                     warnings: [],
                     output: {
-                        sink0: {
+                        view0: {
                             data: [{type: 'point', point: {foo: 'bar', 'time:date': '1970-01-01T00:00:00.000Z'}}],
                             options: {
                                 _jut_time_bounds: []
@@ -839,7 +839,7 @@ describe('Juttle Engine Tests', function() {
                     errors: [],
                     warnings: [],
                     output: {
-                        sink0: {
+                        view0: {
                             data: [{type: 'mark', 'time:date': '1970-01-01T00:00:00.000Z'},
                                    {type: 'point', point: {'time:date': '1970-01-01T00:00:00.000Z'}},
                                    {type: 'point', point: {'time:date': '1970-01-01T00:00:01.000Z'}},
@@ -852,7 +852,7 @@ describe('Juttle Engine Tests', function() {
                             },
                             type: 'text'
                         },
-                        sink1: {
+                        view1: {
                             data: [{type: 'mark', 'time:date': '1970-01-01T00:00:00.000Z'},
                                    {type: 'point', point: {'time:date': '1970-01-01T00:00:00.000Z'}},
                                    {type: 'point', point: {'time:date': '1970-01-01T00:00:01.000Z'}},
@@ -878,7 +878,7 @@ describe('Juttle Engine Tests', function() {
                     errors: [],
                     warnings: [],
                     output: {
-                        sink0: {
+                        view0: {
                             data: [{type: 'point', point: {foo: 'bar', 'time:date': '1970-01-01T00:00:00.000Z'}}],
                             options: {
                                 _jut_time_bounds: []
@@ -906,7 +906,7 @@ describe('Juttle Engine Tests', function() {
                     errors: [],
                     warnings: [],
                     output: {
-                        sink0: {
+                        view0: {
                             data: [{type: 'point', point: {foo: 'baz', 'time:date': '1970-01-01T00:00:00.000Z'}}],
                             options: {
                                 _jut_time_bounds: []
@@ -932,13 +932,13 @@ describe('Juttle Engine Tests', function() {
                                 filename: 'main',
                                 start: {column: 1, line: 1, offset: 0}
                             },
-                            procName: 'read-file'
+                            procName: 'read'
                         },
-                        message: 'Error: internal error Error: ENOENT: no such file or directory, open \'nobody\''
+                        message: 'internal error Error: ENOENT: no such file or directory, open \'nobody\''
                     }],
                     warnings: [],
                     output: {
-                        sink0: {
+                        view0: {
                             data: [],
                             options: {
                                 _jut_time_bounds: [{from: null, last: null, to: null}]
@@ -968,10 +968,10 @@ describe('Juttle Engine Tests', function() {
                             },
                             procName: 'sort'
                         },
-                        message: 'Warning: field "nobody" does not exist'
+                        message: 'field "nobody" does not exist'
                     }],
                     output: {
-                        sink0: {
+                        view0: {
                             data: [{type: 'point', point: {}}],
                             options: {
                                 _jut_time_bounds: []
@@ -1130,8 +1130,8 @@ describe('Juttle Engine Tests', function() {
                 bundle: {program: 'import \"module.juttle\" as mod;' +
                          'input my_input: dropdown -label "My Input" -items [10, 20, 30];' +
                          'input my_date_input: date;' +
-                         'emit -limit 5 | put fromInput = true, val=my_input, datePlus2s = my_date_input + :2s: | batch -every :1s: | view table;' +
-                         'emit -limit 5 | put val2=mod.val | batch -every :1s: | view logger',
+                         'emit -limit 2 -every :2s: | put fromInput = true, val=my_input, datePlus2s = my_date_input + :2s: | batch -every :2s: | view table;' +
+                         'emit -limit 2 -every :2s: | put val2=mod.val | batch -every :2s: | view logger',
                          modules: {
                              'module.juttle': 'export const val=30;'
                          }
@@ -1160,8 +1160,8 @@ describe('Juttle Engine Tests', function() {
                         if (data.type === 'job_start') {
                             got_job_start = true;
                             expect(data.job_id === job_id);
-                            expect(data.sinks[0].sink_id).to.match(/sink\d+/);
-                            expect(data.sinks[1].sink_id).to.match(/sink\d+/);
+                            expect(data.sinks[0].sink_id).to.match(/view\d+/);
+                            expect(data.sinks[1].sink_id).to.match(/view\d+/);
 
                             // Change the sink ids to just "sink" to
                             // allow for an exact match of the full
@@ -1190,33 +1190,28 @@ describe('Juttle Engine Tests', function() {
 
                             // Now check that we received all the ticks/marks/etc we expected.
                             expect(got_job_start).to.be.true;
-                            expect(num_points).to.equal(10);
+                            expect(num_points).to.equal(4);
 
-                            // We allow fewer ticks because ticks
-                            // occur every second on the second while
-                            // the points are emitted from :now:,
-                            // which may not land exactly on a given
-                            // second.
-                            expect(num_ticks).to.be.within(8,10);
+                            expect(num_ticks).to.equal(2);
 
-                            expect(num_marks).to.be.equal(12);
+                            expect(num_marks).to.be.equal(6);
                             expect(num_sink_ends).to.equal(2);
                             done();
                         } else if (data.type === 'tick') {
                             num_ticks++;
-                            expect(data.sink_id).to.match(/sink\d+/);
+                            expect(data.sink_id).to.match(/view\d+/);
                             expect(data.job_id).to.equal(job_id);
                         } else if (data.type === 'mark') {
                             num_marks++;
-                            expect(data.sink_id).to.match(/sink\d+/);
+                            expect(data.sink_id).to.match(/view\d+/);
                             expect(data.job_id).to.equal(job_id);
                         } else if (data.type === 'sink_end') {
                             num_sink_ends++;
-                            expect(data.sink_id).to.match(/sink\d+/);
+                            expect(data.sink_id).to.match(/view\d+/);
                             expect(data.job_id).to.equal(job_id);
                         } else if (data.type === 'points') {
                             num_points++;
-                            expect(data.sink_id).to.match(/sink\d+/);
+                            expect(data.sink_id).to.match(/view\d+/);
                             expect(data.job_id).to.equal(job_id);
                             expect(data.points).to.have.length(1);
 
@@ -1695,7 +1690,7 @@ describe('Juttle Engine Tests', function() {
                     info: {
                         bundle: bundle,
                         err: {
-                            message: 'Error: Cannot run a program without a flowgraph.',
+                            message: 'Cannot run a program without a flowgraph.',
                             code: 'RT-PROGRAM-WITHOUT-FLOWGRAPH',
                             info: {
                                 location: {

--- a/test/juttle-subprocess.spec.js
+++ b/test/juttle-subprocess.spec.js
@@ -98,7 +98,7 @@ describe('juttle-subprocess', function() {
         return waitForMessage({ type: 'compile_error' })
         .then(function() {
             var message = findMessage({ type: 'compile_error' });
-            expect(message.err.message).to.contain('Error: adapter waffles not registered');
+            expect(message.err.message).to.contain('adapter waffles not registered');
         });
     });
 
@@ -159,7 +159,7 @@ describe('juttle-subprocess', function() {
         process.emit('message', {
             cmd: 'run',
             bundle: {
-                program: 'emit -limit 2'
+                program: 'emit -limit 2 -every :2s:'
             }
         });
 


### PR DESCRIPTION
And fix any changes to unit tests:

 - Renaming sink -> view in sink/view ids.
 - "Error: " prefix removed from many error messages.
 - read proc renamed.
 - Ticks are emitted only when there are no points.

@demmer @go-oleg @davidvgalbraith 