### PR TITLE
Add a configurable delay before closing websockets.

### DIFF
--- a/lib/job-handlers.js
+++ b/lib/job-handlers.js
@@ -16,6 +16,7 @@ var root_dir;
 function init(options) {
     job_mgr = new JobManager({max_saved_messages: options.max_saved_messages,
                               delayed_job_cleanup: options.delayed_job_cleanup,
+                              delayed_endpoint_close: options.delayed_endpoint_close,
                               config_path: options.config_path});
     observer_mgr = new ObserverManager({job_mgr: job_mgr});
 

--- a/lib/job-manager.js
+++ b/lib/job-manager.js
@@ -22,6 +22,7 @@ var JobManager = Base.extend({
 
         self._max_saved_messages = options.max_saved_messages;
         self._delayed_job_cleanup = options.delayed_job_cleanup;
+        self._delayed_endpoint_close = options.delayed_endpoint_close;
 
         // This object emits job_start/job_end events when jobs are
         // started and deleted.
@@ -99,7 +100,8 @@ var JobManager = Base.extend({
         } else {
             _.extend(job_options, {
                 endpoints: [],
-                max_saved_messages: self._max_saved_messages
+                max_saved_messages: self._max_saved_messages,
+                delayed_endpoint_close: self._delayed_endpoint_close
             });
             job = new WebsocketJuttleJob(job_options);
         }

--- a/lib/routes.js
+++ b/lib/routes.js
@@ -32,6 +32,7 @@ function add_routes(app, options) {
 
     let max_saved_messages = 1024;
     let delayed_job_cleanup = 10000;
+    let delayed_endpoint_close = options.delayed_endpoint_close || 10000;
 
     if (_.has(options.config, 'juttled')) {
         if (_.has(options.config.juttled, 'max_saved_messages')) {
@@ -41,10 +42,15 @@ function add_routes(app, options) {
         if (_.has(options.config.juttled, 'delayed_job_cleanup')) {
             delayed_job_cleanup = options.config.juttled.delayed_job_cleanup;
         }
+
+        if (_.has(options.config.juttled, 'delayed_endpoint_close')) {
+            delayed_endpoint_close = options.config.juttled.delayed_endpoint_close;
+        }
     }
 
     jobs.init({max_saved_messages: max_saved_messages,
                delayed_job_cleanup: delayed_job_cleanup,
+               delayed_endpoint_close: delayed_endpoint_close,
                config_path: options.config_path,
                root_directory: options.root_directory});
     paths.init({root_directory: options.root_directory});
@@ -89,7 +95,7 @@ function add_routes(app, options) {
               jobs.subscribe_job);
     app.ws(API_PREFIX + '/observers/:observer_id',
               jobs.subscribe_observer);
-    app.ws(API_PREFIX + '/rendezvous/:topic',
+    app.ws('/rendezvous/:topic',
               paths.rendezvous_topic);
 
     return router;

--- a/lib/ws-juttle-job.js
+++ b/lib/ws-juttle-job.js
@@ -24,11 +24,15 @@ var WebsocketJuttleJob = JuttleJob.extend({
         self._job_start_msg = undefined;
         self._job_end_msg = undefined;
 
+        self._delayed_endpoint_close = options.delayed_endpoint_close;
+
         // When this job emits an 'end' event, the program has
         // completed, and we should close all websocket connections.
         self.events.on('end', function() {
-            self._endpoints.forEach(function(endpoint) {
-                endpoint.close();
+            setTimeout(function() {
+                self._endpoints.forEach(function(endpoint) {
+                    endpoint.close();
+                }, self._delayed_endpoint_close);
             });
         });
     },
@@ -79,7 +83,8 @@ var WebsocketJuttleJob = JuttleJob.extend({
             if (self._job_stopped) {
                 logger.debug(self._log_prefix + 'Received job stopped, sending this endpoint a job_stopped message and closing');
                 endpoint.send(self._job_end_msg);
-                endpoint.close();
+                setTimeout(endpoint.close.bind(endpoint),
+                           self._delayed_endpoint_close);
                 return;
             }
         }


### PR DESCRIPTION
Add a new juttled config option delayed_endpoint_close that controls
how long to wait before wanting to close an endpoint and actually
closing the endpoint. It defaults to 10 seconds.

Modify the websocket unit test to close websockets after 2 seconds and
ensure that there is at least 1 second between the job_end message and
the websocket being closed.

This fixes #9.

@demmer  @go-oleg 