### PR TITLE
Bump version of juttle-viewer

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "express": "^4.13.4",
     "juttle": "^0.4.0",
     "juttle-service": "^0.1.0",
-    "juttle-viewer": "0.0.1",
+    "juttle-viewer": "^0.0.2",
     "log4js": "^0.6.31",
     "minimist": "^1.2.0"
   },


### PR DESCRIPTION
Should have the `^` so we get patch fixes.

Was missing my css fix.

@demmer @mstemm 
