### PR TITLE
update paths

### DIFF
--- a/docker/images/outrigger/README.md
+++ b/docker/images/outrigger/README.md
@@ -25,7 +25,7 @@ for demo purposes so you can then use the following link to run the
 "Hello World" juttle program:
 
 ```
-http://<docker_machine_ip>:8080/run?path=/examples/core-juttle/hello_world.juttle
+http://<docker_machine_ip>:8080/?path=/examples/core-juttle/hello_world.juttle
 ```
 
 **docker_machine_ip** on mac/windows is the ip of the virtual machine running
@@ -48,7 +48,7 @@ If you want to run a custom set of juttle programs, mount them in to a directory
 docker run -d -p 8080:8080 -v ./my-juttles:/opt/outrigger/juttles/my-juttles --name outrigger juttle/outrigger:latest
 ```
 
-The juttle programs below ./my-juttles will be accesible via urls of the form ``http://localhost:8080/run?path=/my-juttles/...``.
+The juttle programs below ./my-juttles will be accesible via urls of the form ``http://localhost:8080/?path=/my-juttles/...``.
 
 # Check Container Logs
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -26,7 +26,7 @@ docker-compose -f dc-outrigger.yml -f elastic-newstracker/dc-elastic.yml -f cadv
 If that worked correctly, you should be able to visit this URL in your browser (if running via docker-machine, replace ``localhost`` with IP of the machine):
 
 ```
-http://localhost:8080/run?path=/examples/index.juttle
+http://localhost:8080/?path=/examples/index.juttle
 ```
 
 Click the links in the rendered table to run juttle programs. The Juttle code is provided in subdirectories in ``*.juttle`` files.
@@ -98,7 +98,7 @@ sudo PWD=$PWD docker-compose -f dc-outrigger.yml up
 
 This starts outrigger with all the example .juttle programs below this
 directory pre-loaded. Start by visiting
-``http://localhost:8080/run?path=/examples/index.juttle``, which will output a
+``http://localhost:8080/?path=/examples/index.juttle``, which will output a
 table with links in your browser. Click the links to view the various sets
 of example programs.
 
@@ -159,7 +159,7 @@ outrigger:
 The programs would then be available at:
 
 ```
-http://(localhost|docker machine ip):8080/run?path=/my-juttles/<file>.juttle
+http://(localhost|docker machine ip):8080/?path=/my-juttles/<file>.juttle
 ```
 
 If you want to completely override the built-in set of example juttle

--- a/examples/cadvisor-influx/README.md
+++ b/examples/cadvisor-influx/README.md
@@ -16,7 +16,7 @@ docker-compose -f dc-outrigger.yml -f cadvisor-influx/dc-cadvisor-influx.yml up
 
 Then visit this link to see the Juttle dashboard in your browser:
 
-``http://(localhost|docker machine ip):8080/run?path=/examples/cadvisor-influx/cadvisor-dashboard.juttle``
+``http://(localhost|docker machine ip):8080/?path=/examples/cadvisor-influx/cadvisor-dashboard.juttle``
 
 ## Additional docker-compose configuration
 
@@ -33,7 +33,7 @@ Then visit this link to see the Juttle dashboard in your browser:
 
 We will use Juttle to visualize cpu, memory and network activity of the running docker containers. The Juttle program will read recent metrics from InfluxDB storage.
 
-To run the program, visit ``http://(localhost|docker machine ip):8080/run?path=/examples/cadvisor-influx/cadvisor-dashboard.juttle``
+To run the program, visit ``http://(localhost|docker machine ip):8080/?path=/examples/cadvisor-influx/cadvisor-dashboard.juttle``
 
 The browser window will render this program's output: a table listing of the monitored docker containers, timecharts of their CPU utilization and network activity, and a barchart of memory usage.
 

--- a/examples/core-juttle/README.md
+++ b/examples/core-juttle/README.md
@@ -17,7 +17,7 @@ None needed.
 ## Juttle Programs
 
 To run any of these program, just visit
-``http://(localhost|docker machine ip):8080/run?path=/examples/core-juttle/index.juttle``
+``http://(localhost|docker machine ip):8080/?path=/examples/core-juttle/index.juttle``
 and follow the links.
 
 ### Hello World!

--- a/examples/core-juttle/index.juttle
+++ b/examples/core-juttle/index.juttle
@@ -1,5 +1,5 @@
 sub add_juttle(name, description) {
-    put program="[" + name + "](/run?path=/examples/core-juttle/" + name + ".juttle)", description=description
+    put program="[" + name + "](/?path=/examples/core-juttle/" + name + ".juttle)", description=description
 }
 
 emit |

--- a/examples/elastic-newstracker/README.md
+++ b/examples/elastic-newstracker/README.md
@@ -24,7 +24,7 @@ docker-compose environment is started.
 ## Juttle Programs
 
 To run any of these programs, just visit
-``http://(localhost|docker machine ip):8080/run?path=/examples/elastic-newstracker/index.juttle``, which will output a
+``http://(localhost|docker machine ip):8080/?path=/examples/elastic-newstracker/index.juttle``, which will output a
 table with links in your browser. Click the links to run the example
 programs.
 

--- a/examples/elastic-newstracker/index.juttle
+++ b/examples/elastic-newstracker/index.juttle
@@ -1,6 +1,6 @@
 // Output a table with clickable links to the actual demo programs, for navigation.
 sub add_juttle(name, description) {
-    put program="[" + name + "](/run?path=/examples/elastic-newstracker/" + name + ".juttle)", description=description
+    put program="[" + name + "](/?path=/examples/elastic-newstracker/" + name + ".juttle)", description=description
 }
 
 emit

--- a/examples/gmail/README.md
+++ b/examples/gmail/README.md
@@ -44,7 +44,7 @@ The full set of steps to generate these credentials is [on the README](https://g
 ## Juttle Programs
 
 To run any of these programs, just visit
-``http://(localhost|docker machine ip):8080/run?path=/examples/gmail/index.juttle``
+``http://(localhost|docker machine ip):8080/?path=/examples/gmail/index.juttle``
 and follow the links.
 
 ### Categorizing messages by recipient

--- a/examples/gmail/index.juttle
+++ b/examples/gmail/index.juttle
@@ -1,5 +1,5 @@
 sub add_juttle(name, description) {
-    put program="[" + name + "](/run?path=/examples/gmail/" + name + ".juttle)", description=description
+    put program="[" + name + "](/?path=/examples/gmail/" + name + ".juttle)", description=description
 }
 
 emit |

--- a/examples/index.juttle
+++ b/examples/index.juttle
@@ -1,5 +1,5 @@
 sub add_subdir_juttle(subdir, juttle, description) {
-    put program="[" + subdir + "](/run?path=/examples/" + subdir + "/" + juttle + ".juttle)", description=description
+    put program="[" + subdir + "](/?path=/examples/" + subdir + "/" + juttle + ".juttle)", description=description
 }
 
 emit

--- a/examples/postgres-diskstats/README.md
+++ b/examples/postgres-diskstats/README.md
@@ -31,7 +31,7 @@ examples_outrigger_loader_1 exited with code 0
 
 Then visit this link to see the Juttle dashboard in your browser:
 
-``http://(localhost|docker machine ip):8080/run?path=/examples/postgres-diskstats/throughput.juttle``
+``http://(localhost|docker machine ip):8080/?path=/examples/postgres-diskstats/throughput.juttle``
 
 ## Additional docker-compose configuration
 
@@ -53,7 +53,7 @@ joins the two data streams on matching `host` field, then aggregates the disk th
 regions, subregion, pool. The same data is plotted on a timechart at hourly intervals, and shown in a table as sum totals.
 
 To run this juttle, visit
-`http://(localhost|docker machine ip):8080/run?path=/examples/postgres-diskstats/throughput.juttle`.
+`http://(localhost|docker machine ip):8080/?path=/examples/postgres-diskstats/throughput.juttle`.
 
 ## Experimenting with Juttle
 

--- a/examples/twitter-race/README.md
+++ b/examples/twitter-race/README.md
@@ -30,7 +30,7 @@ To obtain these credentials, set up a [Twitter App](https://apps.twitter.com/) u
 ## Juttle programs
 
 To execute the included Juttle program, visit
-``http://(localhost|docker machine ip):8080/run?path=/examples/twitter-race/twitter.juttle``.
+``http://(localhost|docker machine ip):8080/?path=/examples/twitter-race/twitter.juttle``.
 
 The output will be rendered in your browser. Enter two search terms and click "Run" to see the live charts.
 


### PR DESCRIPTION
Change the default root path to the cwd so the example index.juttle can simply refer to paths starting with /examples.

Also go through all examples and remove `/run` from the URLs.

Tested that when running `/examples/core-juttle/index.juttle`, the various links properly work to load the other juttles.
