### PR TITLE
enforce global 'use strict' is set

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,6 +9,7 @@
         "linebreak-style": [ 2, "unix" ],
         "no-unused-vars": [2, { "args": "none" }],
         "semi": [ 0 ],
-        "quotes": [ 2, "single" ]
+        "quotes": [ 2, "single" ],
+        "strict": [ 2, "global" ] 
     }
 }

--- a/bin/juttle
+++ b/bin/juttle
@@ -1,4 +1,6 @@
 #!/usr/bin/env node
+'use strict';
+
 //
 // Simple helper script to expose the juttle CLI as part of an
 // outrigger installation.

--- a/bin/juttle-engine
+++ b/bin/juttle-engine
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+'use strict';
 
 /* eslint no-console: 0 */
 var _ = require('underscore');

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var eslint = require('gulp-eslint');
 var gulp = require('gulp');
 


### PR DESCRIPTION
this enforces the use of 'use strict' just as we've done in the juttle
repo