### PR TITLE
juttle-engine: updates to match the new service module exports

### DIFF
--- a/lib/juttle-engine.js
+++ b/lib/juttle-engine.js
@@ -2,14 +2,15 @@
 var _ = require('underscore');
 var express = require('express');
 var logger = require('log4js').getLogger('juttle-engine');
-var service = require('juttle-service');
+var service = require('juttle-service').service;
+var logSetup = require('juttle-service').logSetup;
 var viewer = require('juttle-viewer');
 var daemonize = require('daemon');
 
 var app, server;
 
 function run(opts) {
-    service.logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-engine.log'}));
+    logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-engine.log'}));
 
     if (opts.daemonize) {
         daemonize();


### PR DESCRIPTION
The juttle-service module now exports a top-level object with the
service and logSetup as separate exports, so update juttle-engine.js
to match.