### PR TITLE
logging: use the same log4js instance as juttle-service

### DIFF
--- a/lib/juttle-engine.js
+++ b/lib/juttle-engine.js
@@ -1,9 +1,9 @@
 'use strict';
 var _ = require('underscore');
 var express = require('express');
-var logger = require('log4js').getLogger('juttle-engine');
 var service = require('juttle-service').service;
 var logSetup = require('juttle-service').logSetup;
+var getLogger = require('juttle-service').getLogger;
 var viewer = require('juttle-viewer');
 var daemonize = require('daemon');
 
@@ -11,12 +11,13 @@ var app, server;
 
 function run(opts) {
     logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-engine.log'}));
+    var logger = getLogger('juttle-engine')
 
     if (opts.daemonize) {
         daemonize();
     }
 
-    require('log4js').getLogger('juttle-engine').debug('initializing');
+    logger.debug('initializing');
 
     var service_opts = {
         root_directory: opts.root,

--- a/package.json
+++ b/package.json
@@ -38,7 +38,6 @@
     "juttle-sqlite-adapter": "^0.3.1",
     "juttle-twitter-adapter": "^0.2.2",
     "juttle-viewer": "^0.1.0",
-    "log4js": "^0.6.31",
     "minimist": "^1.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Use the juttle-service exported getLogger to make sure that the
configuration applied by logSetup actually takes effect.