### PR TITLE
package.json: add missing bin entries

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.0",
   "description": "juttle execution engine",
   "main": "lib/juttle-engine",
+  "bin": {
+      "juttle": "bin/juttle",
+      "juttle-engine": "bin/juttle-engine",
+      "juttle-engine-client": "bin/juttle-engine-client"
+  },
   "scripts": {
     "test": "gulp test"
   },


### PR DESCRIPTION
This way scripts will be properly put into the bin directory upon
npm install.