### PR TITLE
just using this branch to see how things behave in travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,5 +26,8 @@ script:
     - export SELENIUM_REMOTE_URL='http://localhost:4444/wd/hub'
     - gulp test-coverage
 
+after_failure:
+    - docker logs selenium-node-chrome
+
 after_script:
     - ./test/scripts/stop_selenium_setup.sh

--- a/test/app/lib/juttle-engine-tester.js
+++ b/test/app/lib/juttle-engine-tester.js
@@ -24,6 +24,7 @@ let JuttleEngine = require('../../../lib/juttle-engine');
 let logger = require('juttle-service').getLogger('juttle-engine-tester');
 
 class JuttleEngineTester {
+
     start(cb) {
         findFreePort(10000, 20000)
         .then((port) => {
@@ -32,17 +33,16 @@ class JuttleEngineTester {
             JuttleEngine.run({
                 host: host,
                 port: port,
-                root: '/'
+                root: '/',
+                'log-level': 'debug'
             }, cb);
 
             // Make sure that the node_modules version of chromedriver
             // is first in the path.
             process.env.PATH = path.resolve(__dirname, '../../../node_modules/.bin') +
                                path.delimiter + process.env.PATH;
-            this.driver = new webdriver.Builder()
-                .build();
+            this.driver = new webdriver.Builder().build();
         });
-        this.counter = 0;
     }
 
     stop() {

--- a/test/scripts/start_selenium_setup.sh
+++ b/test/scripts/start_selenium_setup.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 docker run -d -p 4444:4444 --name selenium-hub selenium/hub:2.48.2
-docker run -d --link selenium-hub:hub --name selenium-node-chrome selenium/node-chrome:2.48.2
+docker run -d --link selenium-hub:hub --name selenium-node-chrome -v /dev/shm:/dev/shm  selenium/node-chrome:2.48.2


### PR DESCRIPTION
fixes #31

this is much of a fix really as we're turning on debug logging for
juttle-engine so we can catch issues better when they happen and also
making sure to simply startup a clean juttle-engine and browser session
for each test which seems to have made things more stable.