### PR TITLE
enforce linting of all js files

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -11,7 +11,7 @@ gulp.task('lint', function() {
         'gulpfile.js',
         'bin/*',
         'lib/**/*.js',
-        'test/**/*.spec.js'
+        'test/**/*.js'
     ])
     .pipe(eslint())
     .pipe(eslint.format())


### PR DESCRIPTION
the testing utilities that didn't have the `.spec.js` extension were
not being linted.