### PR TITLE
Add AWS and Cloudwatch example programs.

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -16,6 +16,7 @@ Examples                               | Special instructions
 [gmail](gmail/README.md) | To read from/write to gmail, you need to configure credentials in ``juttle-config.json`` file, see [README](gmail/README.md)
 [postgres-diskstats](postgres-diskstats/README.md) | Supply the yml file to ``docker-compose`` to start additional containers to read from PostgreSQL
 [cadvisor-influx](cadvisor-influx/README.md) | Supply the yml file to ``docker-compose`` to start additional containers to read from InfluxDB
+[aws-cloudwatch](aws-cloudwatch/README.md) | To read from AWS/Cloudwatch, you need to configure credentials in ``juttle-config.json``, see [README](aws-cloudwatch/README.md)
 
 If you wish to run all available examples, this command will start all necessary docker containers:
 

--- a/examples/aws-cloudwatch/README.md
+++ b/examples/aws-cloudwatch/README.md
@@ -1,0 +1,181 @@
+# AWS/Cloudwatch
+
+## Additional docker-compose configuration
+
+The aws adapter by itself does not need any additional docker-compose
+configuration. However, to allow the aws adapter, which only supports
+live real-time reads of aws metrics, to also have a source for
+historical information that is persistent across program invocations,
+we also set up a mysql database and a juttle program that polls from
+the aws adapter and writes to the mysql database.
+
+[dc-aws-cloudwatch.yml](./dc-aws-cloudwatch.yml) in the current directory adds the following containers:
+
+- mysql: A database to hold historical aws information.
+- mysql-createdb: Runs [create_aws_db.sql](./create_aws_db.sql), a script to create the database and table used to hold historical aws information.
+- juttle-aws-poller: Runs [poll_aws.juttle](./poll_aws.juttle), a juttle program that periodically polls from aws, aggregates the raw points into aggregate and demographic information, and writes that information to the mysql database.
+
+## ``juttle-config.json`` configuration
+
+Modify `juttle-config.json` to add ``aws`` and ``cloudwatch`` sections containing credentials to access messages via the AWS and Cloudwatch APIs. As these examples use two separate adapters, both need to be configured.
+
+{
+  "adapters": {
+    "aws": {
+      "access_key": "--YOUR-AWS-ACCESS-KEY-HERE--",
+      "secret_key": "--YOUR-AWS-SECRET-KEY-HERE--",
+      "region": "--YOUR-REGION--HERE"
+    },
+    "cloudwatch": {
+      "access_key": "--YOUR-AWS-ACCESS-KEY-HERE--",
+      "secret_key": "--YOUR-AWS-SECRET-KEY-HERE--",
+      "region": "--YOUR-REGION--HERE"
+    },
+  }
+}
+
+The full set of steps to generate these credentials is [on the README](https://github.com/juttle/juttle-aws-adapter) page on github.
+
+## Juttle Programs
+
+To run any of these programs, just visit
+``http://(localhost|docker machine ip):8080/?path=/examples/aws-cloudwatch/index.juttle``
+and follow the links.
+
+### Polling script and `aggregate_all` subgraph
+
+The polling script [poll_aws.juttle](./poll_aws.juttle) uses the `aggregate_all` subgraph implemented in the file [aws_module.juttle](https://github.com/juttle/juttle-aws-adapter/blob/master/aws_module.juttle) to transform the raw points returned from the various AWS APIs into aggregate and demographic summaries of your AWS infrastructure.
+
+It then writes the resulting points to the table `aws_aggregation` in the mysql database. This allows for a source of historical aws information that is persistent across invocations of individual juttle programs.
+
+In turn, when the example programs want to read aws aggregate/demographic information, they read from the mysql database using `read mysql -table 'aws_aggregation' ...`.
+
+### AWS Overview
+
+This program demonstrates ways to use the aggregate and demographic information from the aws adapter as well as ways to use the cloudwatch adapter to identify problems.
+
+The program shows a sample of aggregate and demographic information from AWS:
+
+- The number of EC2 instances
+- The total amount of RDS allocated storage
+- The total EBS volume capacity
+
+This program also identifies "problem" items and shows the number of items as a count and details as a table.
+
+For this program, "problem" items are:
+- EC2: Any instances with failed status checks.
+- ELB: Any load balancers where UnHealthyHostCount is > 0
+- Lambda: Any function with errors > 0
+
+View this program: [overview.juttle](./overview.juttle)
+
+### AWS Demographics
+
+This program displays AWS aggregate metrics (e.g. Number of EC2
+instances, # EBS volumes, etc.) and demographic metrics (breakdown
+by EC2 instance type, EBS volume type, etc) for a given product.
+
+Input controls let you choose the product, aggregate metric, and
+demographic metric, and display timecharts and piecharts with the
+values of the metric for the given product.
+
+Optionally, the timecharts also overlay events such as
+additions/removals/changes to the set of items (i.e. EC2 instances,
+etc).
+
+View this program: [demographic.juttle](./demographic.juttle)
+
+### Capactity Planning
+
+This is a collection of individual juttle programs that can be used to guide capacity planning decisions for several AWS products.
+
+#### AutoScaling
+
+This program can be used to guide decisions on capacity planning
+for AutoScaling groups. It shows a timechart of the actual total
+number of instances in all AutoScaling groups along with the total
+desired capacity of all AutoScaling groups.
+
+If the actual group size is consistently higher or lower than the
+desired capacity, you may want to change the desired capacity to
+more properly match the actual group size.
+
+View this program: [capacity_planning/autoscaling.juttle](./capacity_planning/autoscaling.juttle)
+
+#### EBS
+
+This program can be used to guide decisions on capacity planning
+for EBS volumes. It shows the average IO ops/second for all volumes
+combined) and compares that to the configured total Iops capacity
+of the entire collection of volumes.
+If the total IO acticity is close to the Iops capacity, you may
+want to consider adding more volumes or faster volumes to spread
+the work across more items.
+
+View this program: [capacity_planning/ebs.juttle](./capacity_planning/ebs.juttle)
+
+#### EC2
+
+This program relies on a common subgraraph
+[capacity_planning_cpu.juttle](./common/capacity_planning_cpu.juttle)
+that can be used to guide decisions on capacity planning for any AWS
+Product that has a CloudWatch metric called 'CPUUtilization'
+(e.g. EC2, RDS, ElastiCache). It shows the average CPU Utilization for
+all items (EC2 instances/RDS databases/ElastiCache clusters) over a
+recent timeframe as well as the idle time for the same set of items.
+
+If the CPU Utilization is close to 100%, you may want to consider
+adding more instances/databases/etc to spread the work across more
+items.
+
+Additionally, the program displays a pie chart of EC2 instance types
+scaled by hourly cost. This allows you to identify the instance type
+that is the greatest contributor to cost.
+
+View these programs:
+- [common/capacity_planning_cpu.juttle](./common/capacity_planning_cpu.juttle)
+- [capacity_planning/ec2.juttle]((./capacity_planning/ec2.juttle)
+
+#### ElastiCache
+
+Like EC2, this program relies on capacity_planning_cpu.juttle to show
+average CPU utilization for all cache nodes.
+
+View these programs:
+- [common/capacity_planning_cpu.juttle](./common/capacity_planning_cpu.juttle)
+- [capacity_planning/elasticache.juttle]((./capacity_planning/elasticache.juttle)
+
+#### RDS
+
+This program can be used to guide decisions on capacity planning
+for RDS databases. It generates three piecharts:
+
+1. Comparing total Iops to configured Iops.
+2. Showing storage space used to configured storage space.
+3. Showing average CPU Utilization across all DB instances.
+
+The first pie chart shows the average IO ops/second for all DB
+instances (combined) and compares that to the configured total Iops
+capacity of the entire collection of DB instances.
+
+If the total IO acticity is close to the Iops capacity, you may
+want to consider adding more databases or faster databases to
+spread the work across more items.
+
+IMPORTANT NOTE: In some cases, a RDS DB Instance will not have a
+value for provisioned Iops, in which case the Iops_Headroom value
+will incorrectly show a lower value than the actual headroom.
+
+The second pie chart shows the total space used across all DB
+insttances and compares that to the total allocated storage for all
+DB instances.
+
+If the total space used is close to capacity, you may want to
+consider adding more storage to your DB instances.
+
+The third pie chart uses the common subgraph in
+common/capacity_planning_cpu.juttle to show the average CPU
+utilization for all DB intances.
+
+If the CPU utilization is very low or very high, you may want to
+change DB classes of your instances.

--- a/examples/aws-cloudwatch/README.md
+++ b/examples/aws-cloudwatch/README.md
@@ -85,7 +85,7 @@ etc).
 
 View this program: [demographic.juttle](./demographic.juttle)
 
-### Capactity Planning
+### Capacity Planning
 
 This is a collection of individual juttle programs that can be used to guide capacity planning decisions for several AWS products.
 
@@ -106,9 +106,9 @@ View this program: [capacity_planning/autoscaling.juttle](./capacity_planning/au
 
 This program can be used to guide decisions on capacity planning
 for EBS volumes. It shows the average IO ops/second for all volumes
-combined) and compares that to the configured total Iops capacity
+(combined) and compares that to the configured total Iops capacity
 of the entire collection of volumes.
-If the total IO acticity is close to the Iops capacity, you may
+If the total IO activity is close to the Iops capacity, you may
 want to consider adding more volumes or faster volumes to spread
 the work across more items.
 
@@ -116,7 +116,7 @@ View this program: [capacity_planning/ebs.juttle](./capacity_planning/ebs.juttle
 
 #### EC2
 
-This program relies on a common subgraraph
+This program relies on a common subgraph
 [capacity_planning_cpu.juttle](./common/capacity_planning_cpu.juttle)
 that can be used to guide decisions on capacity planning for any AWS
 Product that has a CloudWatch metric called 'CPUUtilization'

--- a/examples/aws-cloudwatch/capacity_planning/autoscaling.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/autoscaling.juttle
@@ -8,8 +8,8 @@
 // more properly match the actual group size.
 //
 
-read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end: product='AutoScaling'
-    | filter metric_type='AWS Aggregate' AND
+read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end:
+    product='AutoScaling' AND metric_type='AWS Aggregate' AND
              (aggregate='AutoScaling Group Total Size' OR aggregate='AutoScaling Group Total Desired Capacity')
     | view timechart -keyField "aggregate"
                      -valueField "value"

--- a/examples/aws-cloudwatch/capacity_planning/autoscaling.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/autoscaling.juttle
@@ -1,0 +1,20 @@
+// This program can be used to guide decisions on capacity planning
+// for AutoScaling groups. It shows a timechart of the actual total
+// number of instances in all AutoScaling groups along with the total
+// desired capacity of all AutoScaling groups.
+//
+// If the actual group size is consistently higher or lower than the
+// desired capacity, you may want to change the desired capacity to
+// more properly match the actual group size.
+//
+
+read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end: product='AutoScaling'
+    | filter metric_type='AWS Aggregate' AND
+             (aggregate='AutoScaling Group Total Size' OR aggregate='AutoScaling Group Total Desired Capacity')
+    | view timechart -keyField "aggregate"
+                     -valueField "value"
+                     -title "AWS Capacity Planning (AutoScaling)"
+                     -yScales.primary.label "Value"
+                     -markerSize 2;
+
+

--- a/examples/aws-cloudwatch/capacity_planning/ebs.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/ebs.juttle
@@ -3,15 +3,15 @@
 // (combined) and compares that to the configured total Iops capacity
 // of the entire collection of volumes.
 //
-// If the total IO acticity is close to the Iops capacity, you may
+// If the total IO activity is close to the Iops capacity, you may
 // want to consider adding more volumes or faster volumes to spread
 // the work across more items.
 
 (read cloudwatch -period 3600 -last :1h: product='EBS'
  | filter name='VolumeReadOps' OR name='VolumeWriteOps'
  | reduce Iops_Used=sum(value)/(3600.0);
-read mysql -table 'aws_aggregation' -from :1 hour ago: -to :now: product='EBS'
- | filter aggregate='EBS Volume Total Iops'
+ read mysql -table 'aws_aggregation' -last :1h:
+   product='EBS' AND aggregate='EBS Volume Total Iops'
  | reduce Iops_Total=last(value)
 )
     | join

--- a/examples/aws-cloudwatch/capacity_planning/ebs.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/ebs.juttle
@@ -1,0 +1,23 @@
+// This program can be used to guide decisions on capacity planning
+// for EBS volumes. It shows the average IO ops/second for all volumes
+// (combined) and compares that to the configured total Iops capacity
+// of the entire collection of volumes.
+//
+// If the total IO acticity is close to the Iops capacity, you may
+// want to consider adding more volumes or faster volumes to spread
+// the work across more items.
+
+(read cloudwatch -period 3600 -last :1h: product='EBS'
+ | filter name='VolumeReadOps' OR name='VolumeWriteOps'
+ | reduce Iops_Used=sum(value)/(3600.0);
+read mysql -table 'aws_aggregation' -from :1 hour ago: -to :now: product='EBS'
+ | filter aggregate='EBS Volume Total Iops'
+ | reduce Iops_Total=last(value)
+)
+    | join
+    | put Iops_Headroom=Iops_Total-Iops_Used
+    | keep Iops_Used, Iops_Headroom
+    | split
+    | view piechart -title "AWS Capacity Planning (Iops) for EBS";
+
+

--- a/examples/aws-cloudwatch/capacity_planning/ec2.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/ec2.juttle
@@ -1,0 +1,32 @@
+import "examples/aws-cloudwatch/common/capacity_planning_cpu.juttle" as capacity_cpu;
+
+capacity_cpu.cpu_piechart -cw_product 'EC2';
+
+// Also display a pie chart of EC2 instance types scaled by hourly
+// cost. These costs are accurate as of 2016-02-17.
+const instance_prices = {
+    'm3.medium': 0.0087,
+    'm1.small': 0.0081,
+    'm3.large': 0.133,
+    'm1.medium': 0.0133,
+    't1.micro': 0.0031,
+    'c3.xlarge': 0.02,
+    't2.micro': 0.013,
+    'c3.8xlarge': 1.68,
+    'm4.4xlarge': 0.958,
+    'm3.2xlarge': 0.532,
+    'c3.large': 0.105,
+    'c4.2xlarge': 0.419,
+    'm3.xlarge': 0.266,
+    't2.small': 0.026,
+    't2.medium': 0.05,
+};
+
+read mysql -table 'aws_aggregation' -from :0: -to :end: product='EC2'
+    | filter demographic='EC2 Instance Type'
+    | put cost=value*instance_prices[name]
+    | view piechart -valueField "cost" -title "EC2 Instances Scaled by Hourly Cost" -categoryField "name";
+
+
+
+

--- a/examples/aws-cloudwatch/capacity_planning/ec2.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/ec2.juttle
@@ -22,8 +22,8 @@ const instance_prices = {
     't2.medium': 0.05,
 };
 
-read mysql -table 'aws_aggregation' -from :0: -to :end: product='EC2'
-    | filter demographic='EC2 Instance Type'
+read mysql -table 'aws_aggregation' -from :0: -to :end:
+    product='EC2' AND demographic='EC2 Instance Type'
     | put cost=value*instance_prices[name]
     | view piechart -valueField "cost" -title "EC2 Instances Scaled by Hourly Cost" -categoryField "name";
 

--- a/examples/aws-cloudwatch/capacity_planning/elasticache.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/elasticache.juttle
@@ -1,0 +1,3 @@
+import "examples/aws-cloudwatch/common/capacity_planning_cpu.juttle" as capacity_cpu;
+
+capacity_cpu.cpu_piechart -cw_product 'ElastiCache';

--- a/examples/aws-cloudwatch/capacity_planning/index.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/index.juttle
@@ -1,5 +1,5 @@
 sub add_juttle(juttle, description) {
-    put program="[" + juttle + "](/?path=/examples/aws-cloudwatch/capacity_planning/" + juttle + ".juttle)", description=description
+    put program="[${juttle}](/?path=/examples/aws-cloudwatch/capacity_planning/${juttle}.juttle)", description=description
 }
 
 emit

--- a/examples/aws-cloudwatch/capacity_planning/index.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/index.juttle
@@ -1,0 +1,14 @@
+sub add_juttle(juttle, description) {
+    put program="[" + juttle + "](/?path=/examples/aws-cloudwatch/capacity_planning/" + juttle + ".juttle)", description=description
+}
+
+emit
+|(
+    add_juttle -juttle "autoscaling" -description "Capacity Planning for Autoscaling";
+    add_juttle -juttle "ebs" -description "Capacity Planning for EBS";
+    add_juttle -juttle "ec2" -description "Capacity Planning for EC2";
+    add_juttle -juttle "elasticache" -description "Capacity Planning for ElastiCache";
+    add_juttle -juttle "rds" -description "Capacity Planning for RDS"
+)
+| keep program, description
+| view table -title 'Example Juttle Programs' -markdownFields [ 'program' ]

--- a/examples/aws-cloudwatch/capacity_planning/rds.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/rds.juttle
@@ -37,8 +37,8 @@ import "examples/aws-cloudwatch/common/capacity_planning_cpu.juttle" as capacity
  | reduce avg_iops=avg(value) by item, name
  | reduce Iops_Used=sum(avg_iops)
  | keep Iops_Used;
-read mysql -table 'aws_aggregation' -from :1 hour ago: -to :now: product='RDS'
- | filter aggregate='RDS DB Total Iops'
+ read mysql -table 'aws_aggregation' -last :1h:
+   product='RDS' AND aggregate='RDS DB Total Iops'
  | reduce Iops_Total=last(value)
 )
  | join
@@ -51,9 +51,9 @@ read mysql -table 'aws_aggregation' -from :1 hour ago: -to :now: product='RDS'
  | filter name='FreeStorageSpace'
  | reduce avg_freespace=avg(value)/(1024*1024*1024) by item
  | reduce Storage_Headroom=sum(avg_freespace);
-read mysql -table 'aws_aggregation' -from :1 hour ago: -to :now: product='RDS'
- | filter aggregate='RDS DB Total Allocated Storage'
- | reduce Storage_Allocated=last(value)
+ read mysql -table 'aws_aggregation' -last :1h:
+   product='RDS' AND aggregate='RDS DB Total Allocated Storage'
+ | tail 1 | keep value | put Storage_Allocated=value
 )
  | join
  | put Storage_Used=Storage_Allocated-Storage_Headroom

--- a/examples/aws-cloudwatch/capacity_planning/rds.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/rds.juttle
@@ -1,0 +1,65 @@
+// This program can be used to guide decisions on capacity planning
+// for RDS databases. It generates three piecharts:
+//   1. Comparing total Iops to configured Iops.
+//   2. Showing storage space used to configured storage space.
+//   3. Showing average CPU Utilization across all DB instances.
+//
+// The first pie chart shows the average IO ops/second for all DB
+// instances (combined) and compares that to the configured total Iops
+// capacity of the entire collection of DB instances.
+//
+// If the total IO acticity is close to the Iops capacity, you may
+// want to consider adding more databases or faster databases to
+// spread the work across more items.
+//
+// IMPORTANT NOTE: In some cases, a RDS DB Instance will not have a
+// value for provisioned Iops, in which case the Iops_Headroom value
+// will incorrectly show a lower value than the actual headroom.
+//
+// The second pie chart shows the total space used across all DB
+// insttances and compares that to the total allocated storage for all
+// DB instances.
+//
+// If the total space used is close to capacity, you may want to
+// consider adding more storage to your DB instances.
+//
+// The third pie chart uses the common subgraph in
+// common/capacity_planning_cpu.juttle to show the average CPU
+// utilization for all DB intances.
+//
+// If the CPU utilization is very low or very high, you may want to
+// change DB classes of your instances.
+
+import "examples/aws-cloudwatch/common/capacity_planning_cpu.juttle" as capacity_cpu;
+
+(read cloudwatch -period 3600 -last :1h: product='RDS'
+ | filter (name='ReadIOPS' OR name='WriteIOPS')
+ | reduce avg_iops=avg(value) by item, name
+ | reduce Iops_Used=sum(avg_iops)
+ | keep Iops_Used;
+read mysql -table 'aws_aggregation' -from :1 hour ago: -to :now: product='RDS'
+ | filter aggregate='RDS DB Total Iops'
+ | reduce Iops_Total=last(value)
+)
+ | join
+ | put Iops_Headroom=Iops_Total-Iops_Used
+ | keep Iops_Used, Iops_Headroom
+ | split
+ | view piechart -title "AWS Capacity Planning (Iops) for RDS";
+
+(read cloudwatch -period 3600 -last :1h: product='RDS'
+ | filter name='FreeStorageSpace'
+ | reduce avg_freespace=avg(value)/(1024*1024*1024) by item
+ | reduce Storage_Headroom=sum(avg_freespace);
+read mysql -table 'aws_aggregation' -from :1 hour ago: -to :now: product='RDS'
+ | filter aggregate='RDS DB Total Allocated Storage'
+ | reduce Storage_Allocated=last(value)
+)
+ | join
+ | put Storage_Used=Storage_Allocated-Storage_Headroom
+ | keep Storage_Used, Storage_Headroom
+ | split
+ | view piechart -title "AWS Capacity Planning (Storage) for RDS";
+
+capacity_cpu.cpu_piechart -cw_product 'RDS';
+

--- a/examples/aws-cloudwatch/common/aws_control_aggregate.juttle
+++ b/examples/aws-cloudwatch/common/aws_control_aggregate.juttle
@@ -1,0 +1,28 @@
+// This juttle program contains common controls used by the other AWS
+// juttle programs. It is not meant to be run by itself.
+
+import "examples/aws-cloudwatch/common/aws_control_product.juttle" as control_product;
+
+const all_aggregates = {
+    'EC2': [{label: 'EC2 Instance Count', value: 'EC2 Instance Count'}],
+    'EBS': [{label: 'EBS Volume Count', value: 'EBS Volume Count'},
+            {label: 'EBS Volume Total Size', value: 'EBS Volume Total Size'},
+            {label: 'EBS Volume Total iops', value: 'EBS Volume Total iops'}],
+    'ELB': [{label: 'ELB Load Balancer Count', value: 'ELB Load Balancer Count'}],
+    'RDS': [{label: 'RDS DB Count', value: 'RDS DB Count'},
+            {label: 'RDS DB Total Allocated Storage', value: 'RDS DB Total Allocated Storage'},
+            {label: 'RDS DB Total Iops', value: 'RDS DB Total Iops'}],
+    'CloudFront': [{label: 'CF Distribution Count', value: 'CF Distribution Count'}],
+    'AutoScaling': [{label: 'AutoScaling Group Count', value: 'AutoScaling Group Count'},
+                    {label: 'AutoScaling Group Total Size', value: 'AutoScaling Group Total Size'},
+                    {label: 'AutoScaling Group Total Desired Capacity', value: 'AutoScaling Group Total Desired Capacity'}],
+    'ElastiCache': [{label: 'ElastiCache Cluster Count', value: 'ElastiCache Cluster Count'},
+                    {label: 'ElastiCache Total Cache Nodes', value: 'ElastiCache Total Cache Nodes'}],
+    'Lambda': [{label: 'Lambda Function Count', value: 'Lambda Function Count'},
+               {label: 'Lambda Total Memory Size', value: 'Lambda Total Memory Size'}]
+};
+
+export input agg_in: select
+    -label 'Aggregate'
+    -items all_aggregates[control_product.product_in]
+    -default '(null)';

--- a/examples/aws-cloudwatch/common/aws_control_demographic.juttle
+++ b/examples/aws-cloudwatch/common/aws_control_demographic.juttle
@@ -1,0 +1,46 @@
+// This juttle program contains common controls used by the other AWS
+// juttle programs. It is not meant to be run by itself.
+
+import "examples/aws-cloudwatch/common/aws_control_product.juttle" as control_product;
+
+const all_demographics = {
+    'EC2': [{label: 'EC2 Instance Type', value: 'EC2 Instance Type'},
+            {label: 'EC2 Root Device Type', value: 'EC2 Root Device Type'},
+            {label: 'EC2 State', value: 'EC2 State'}],
+    'EBS': [{label: 'EBS Volume Type', value: 'EBS Volume Type'},
+            {label: 'EBS State', value: 'EBS State'},
+            {label: 'EBS Status', value: 'EBS Status'}],
+    'ELB': [{label: 'ELB Scheme', value: 'ELB Scheme'},
+            {label: 'ELB Health Check Target', value: 'ELB Health Check Target'}],
+    'RDS': [{label: 'RDS DB Class', value: 'RDS DB Class'},
+            {label: 'RDS DB Engine', value: 'RDS DB Engine'},
+            {label: 'RDS DB Engine Version', value: 'RDS DB Engine Version'},
+            {label: 'RDS DB License Model', value: 'RDS DB License Model'},
+            {label: 'RDS DB Retention Period', value: 'RDS DB Retention Period'},
+            {label: 'RDS DB PubliclyAccessible', value: 'RDS DB PubliclyAccessible'},
+            {label: 'RDS DB Storage Type', value: 'RDS DB Storage Type'},
+            {label: 'RDS DB Status', value: 'RDS DB Status'},
+            {label: 'RDS DB Read Replica Status', value: 'RDS DB Read Replica Status'}],
+    'CloudFront': [{label: 'CF Status', value: 'CF Status'},
+                   {label: 'CF Price Class', value: 'CF Price Class'},
+                   {label: 'CF Enabled', value: 'CF Enabled'}],
+    'AutoScaling': [{label: 'AutoScaling Desired Capacity', value: 'AutoScaling Desired Capacity'},
+                    {label: 'AutoScaling Current Group Size', value: 'AutoScaling Current Group Size'},
+                    {label: 'AutoScaling Health Check Type', value: 'AutoScaling Health Check Type'}],
+    'ElastiCache': [{label: 'ElastiCache Cache Node Type', value: 'ElastiCache Cache Node Type'},
+                    {label: 'ElastiCache Engine', value: 'ElastiCache Engine'},
+                    {label: 'ElastiCache Engine Version', value: 'ElastiCache Engine Version'},
+                    {label: 'ElastiCache Cluster Status', value: 'ElastiCache Cluster Status'},
+                    {label: 'ElastiCache Num Cache Nodes', value: 'ElastiCache Num Cache Nodes'}],
+    'Lambda': [{label: 'Lambda Runtime', value: 'Lambda Runtime'},
+               {label: 'Lambda Role', value: 'Lambda Role'},
+               {label: 'Lambda Timeout', value: 'Lambda Timeout'},
+               {label: 'Lambda Memory Size', value: 'Lambda Memory Size'},
+               {label: 'Lambda Version', value: 'Lambda Version'},
+               {label: 'Lambda Handler', value: 'Lambda Handler'}]
+};
+
+export input demo_in: select
+    -label 'Demographic'
+    -items all_demographics[control_product.product_in]
+    -default '(null)';

--- a/examples/aws-cloudwatch/common/aws_control_events.juttle
+++ b/examples/aws-cloudwatch/common/aws_control_events.juttle
@@ -1,0 +1,7 @@
+// This juttle program contains common controls used by the other AWS
+// juttle programs. It is not meant to be run by itself.
+
+export input show_events_in: select
+    -label 'Show Events'
+    -items [{label: 'Yes', value: "*"}, {label: 'No', value: "Impossible"} ]
+    -default '*';

--- a/examples/aws-cloudwatch/common/aws_control_product.juttle
+++ b/examples/aws-cloudwatch/common/aws_control_product.juttle
@@ -1,0 +1,14 @@
+// This juttle program contains common controls used by the other AWS
+// juttle programs. It is not meant to be run by itself.
+
+export input product_in: select
+    -label 'AWS Product'
+    -items [{value: 'EC2', label: 'EC2'},
+            {value: 'EBS', label: 'EBS'},
+            {value: 'ELB', label: 'ELB'},
+            {value: 'RDS', label: 'RDS'},
+            {value: 'CloudFront', label: 'CloudFront'},
+            {value: 'AutoScaling', label: 'AutoScaling'},
+            {value: 'ElastiCache', label: 'ElastiCache'},
+            {value: 'Lambda', label: 'Lambda'}]
+    -default 'EC2';

--- a/examples/aws-cloudwatch/common/capacity_planning_cpu.juttle
+++ b/examples/aws-cloudwatch/common/capacity_planning_cpu.juttle
@@ -13,9 +13,8 @@ export sub cpu_piechart(cw_product) {
 
     read cloudwatch -period 3600 -last :1h: product=cw_product
         | filter name='CPUUtilization'
-        | reduce used_cpu=avg(value) by item
-        | reduce avg_used_cpu=avg(used_cpu)
-        | put CPU_Used=avg_used_cpu, CPU_Headroom=100-avg_used_cpu
+        | reduce used_cpu=avg(value)
+        | put CPU_Used=used_cpu, CPU_Headroom=100-used_cpu
         | keep CPU_Used, CPU_Headroom
         | split
         | view piechart -title "AWS Capacity Planning (CPU Usage) for ${cw_product}";

--- a/examples/aws-cloudwatch/common/capacity_planning_cpu.juttle
+++ b/examples/aws-cloudwatch/common/capacity_planning_cpu.juttle
@@ -1,0 +1,22 @@
+// This subgraph can be used to guide decisions on capacity planning
+// for any AWS Product that has a CloudWatch metric called
+// 'CPUUtilization' (e.g. EC2, RDS, ElastiCache). It shows the average
+// CPU Utilization for all items (EC2 instances/RDS
+// databases/ElastiCache clusters) over a recent timeframe as well as
+// the idle time for the same set of items.
+//
+// If the CPU Utilization is close to 100%, you may want to consider
+// adding more instances/databases/etc to spread the work across more
+// items.
+
+export sub cpu_piechart(cw_product) {
+
+    read cloudwatch -period 3600 -last :1h: product=cw_product
+        | filter name='CPUUtilization'
+        | reduce used_cpu=avg(value) by item
+        | reduce avg_used_cpu=avg(used_cpu)
+        | put CPU_Used=avg_used_cpu, CPU_Headroom=100-avg_used_cpu
+        | keep CPU_Used, CPU_Headroom
+        | split
+        | view piechart -title "AWS Capacity Planning (CPU Usage) for ${cw_product}";
+}

--- a/examples/aws-cloudwatch/create_aws_db.sql
+++ b/examples/aws-cloudwatch/create_aws_db.sql
@@ -1,0 +1,13 @@
+CREATE DATABASE IF NOT EXISTS aws;
+USE aws;
+CREATE TABLE IF NOT EXISTS aws_aggregation (
+       time TIMESTAMP,
+       name VARCHAR(128),
+       value INTEGER UNSIGNED,
+       aggregate VARCHAR(128),
+       demographic VARCHAR(128),
+       metric_type VARCHAR(128),
+       product VARCHAR(128),
+
+       INDEX aws_metrics_idx (time)
+);

--- a/examples/aws-cloudwatch/dc-aws-cloudwatch.yml
+++ b/examples/aws-cloudwatch/dc-aws-cloudwatch.yml
@@ -1,0 +1,45 @@
+# The aws adapter by itself does not need any additional
+# docker-compose configuration. However, to allow the aws adapter,
+# which only supports live real-time reads of aws metrics, to also
+# have a source for historical information, we also set up a mysql
+# database and a juttle program that polls from the aws adapter and
+# writes to the mysql database.
+
+mysql:
+  container_name: examples_mysql_1
+  image: mysql:latest
+  environment:
+    - MYSQL_ROOT_PASSWORD=my-juttle-password
+  command:
+    - mysqld
+
+juttle-engine:
+  links:
+    - mysql
+  external_links:
+    - examples_mysql_1
+
+# Once docker-compose 1.6 is ready, we should modify this to use
+# docker-compose events. It should allow adding hooks to automatically
+# create the mysql db/table once the mysql container starts, as well
+# as run poll_aws.juttle once the juttle-engine container starts and
+# the mysql db has been created.
+
+mysql-createdb:
+  image: mysql:latest
+  links:
+    - mysql
+    - juttle-engine
+  volumes:
+    - ${PWD}/aws-cloudwatch/create_aws_db.sql:/opt/incoming/create_aws_db.sql
+  command: bash -c "sleep 10 && mysql -u root -h examples_mysql_1 --password=my-juttle-password < /opt/incoming/create_aws_db.sql && tail -f /dev/null"
+
+juttle-aws-poller:
+  container_name: examples_juttle-aws-poller_1
+  image: juttle/juttle-engine:latest
+  links:
+     - mysql
+  volumes:
+     - ${PWD}/juttle-config.json:/opt/juttle-engine/.juttle-config.json
+     - ${PWD}/aws-cloudwatch/poll_aws.juttle:/opt/juttle-engine/poll_aws.juttle
+  command: bash -c "sleep 20 && echo 'Polling from AWS and Writing to Mysql...' && juttle /opt/juttle-engine/poll_aws.juttle"

--- a/examples/aws-cloudwatch/demographic.juttle
+++ b/examples/aws-cloudwatch/demographic.juttle
@@ -1,0 +1,50 @@
+// This program displays AWS aggregate metrics (e.g. Number of EC2
+// instances, # EBS volumes, etc.) and demographic metrics (breakdown
+// by EC2 instance type, EBS volume type, etc) for a given product.
+
+// Input controls let you choose the product, aggregate metric, and
+// demographic metric, and display timecharts and piecharts with the
+// values of the metric for the given product.
+
+// Optionally, the timecharts also overlay events such as
+// additions/removals/changes to the set of items (i.e. EC2 instances,
+// etc).
+
+
+import "examples/aws-cloudwatch/common/aws_control_product.juttle" as control_product;
+import "examples/aws-cloudwatch/common/aws_control_aggregate.juttle" as control_agg;
+import "examples/aws-cloudwatch/common/aws_control_demographic.juttle" as control_demo;
+import "examples/aws-cloudwatch/common/aws_control_events.juttle" as control_events;
+
+read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end:
+    | ( filter metric_type='AWS Aggregate' and aggregate=control_agg.agg_in
+        | view timechart -keyField "aggregate"
+                         -valueField "value"
+                         -title "AWS Totals (${control_product.product_in})"
+                         -yScales.primary.label "Total"
+                         -markerSize 2
+                         -id 'agg_timechart';
+        filter event_type =~ control_events.show_events_in
+        | put icon='fa-cloud'
+        | view events -on 'agg_timechart'
+                      -nameField "event_type"
+                      -messageField "item"
+                      -typeField "icon";
+       filter metric_type='AWS Demographic' AND demographic=control_demo.demo_in
+       | view piechart -categoryField "name"
+                       -valueField "value"
+                       -title "AWS Demographics (${control_demo.demo_in})";
+       filter metric_type='AWS Demographic' AND demographic=control_demo.demo_in
+       | view timechart -keyField "name"
+                        -valueField "value"
+                        -title "AWS Demographics (${control_demo.demo_in})"
+                        -yScales.primary.label "Count"
+                        -markerSize 2
+                        -id 'demo_timechart';
+       filter event_type =~ control_events.show_events_in
+       | put icon='fa-cloud'
+       | view events -on 'demo_timechart'
+                     -nameField "event_type"
+                     -messageField "item"
+                     -typeField "icon";
+      );

--- a/examples/aws-cloudwatch/index.juttle
+++ b/examples/aws-cloudwatch/index.juttle
@@ -1,9 +1,9 @@
 sub add_subdir(subdir, juttle, description) {
-    put program="[" + subdir + "](/?path=/examples/aws-cloudwatch/" + subdir + "/" + juttle + ".juttle)", description=description
+    put program="[${subdir}](/?path=/examples/aws-cloudwatch/${subdir}/${juttle}.juttle)", description=description
 }
 
 sub add_juttle(juttle, description) {
-    put program="[" + juttle + "](/?path=/examples/aws-cloudwatch/" + juttle + ".juttle)", description=description
+    put program="[${juttle}](/?path=/examples/aws-cloudwatch/${juttle}.juttle)", description=description
 }
 
 emit

--- a/examples/aws-cloudwatch/index.juttle
+++ b/examples/aws-cloudwatch/index.juttle
@@ -1,0 +1,16 @@
+sub add_subdir(subdir, juttle, description) {
+    put program="[" + subdir + "](/?path=/examples/aws-cloudwatch/" + subdir + "/" + juttle + ".juttle)", description=description
+}
+
+sub add_juttle(juttle, description) {
+    put program="[" + juttle + "](/?path=/examples/aws-cloudwatch/" + juttle + ".juttle)", description=description
+}
+
+emit
+|(
+    add_juttle -juttle "overview" -description "Overview of AWS infrastructure";
+    add_juttle -juttle "demographic" -description "Demographics of AWS infrastructure";
+    add_subdir -subdir "capacity_planning" -juttle "index" -description "Programs for AWS Capacity Planning";
+)
+| keep program, description
+| view table -title 'Example Juttle Programs' -markdownFields [ 'program' ]

--- a/examples/aws-cloudwatch/overview.juttle
+++ b/examples/aws-cloudwatch/overview.juttle
@@ -1,0 +1,46 @@
+// This program demonstrates ways to use the aggregate and demographic
+// information from the aws adapter as well as ways to use the
+// cloudwatch adapter to identify problems.
+//
+// The program shows sample of aggregate and demographic information
+// from AWS:
+// - The number of EC2 instances
+// - The total amount of RDS allocated storage
+// - The total EBS volume capacity.
+//
+// This program also identifies "problem" items and shows the number
+//   of items as a count and details as a table.
+// For this program, "problem" items are:
+// - EC2: Any instances with failed status checks.
+// - ELB: Any load balancers where UnHealthyHostCount is > 0
+// - Lambda: Any function with errors > 0
+
+read mysql -table 'aws_aggregation' -from :0: -to :end: product='EC2' OR product='EBS' OR product='RDS'
+    | (filter product='EC2' AND metric_type='AWS Aggregate' AND aggregate='EC2 Instance Count'
+       | view tile -title "Number of EC2 Instances";
+       filter product='RDS' AND metric_type='AWS Aggregate' AND aggregate='RDS DB Total Allocated Storage'
+       | view tile -title "Total DB Allocated Storage (GB)";
+       filter product='EBS' AND metric_type='AWS Aggregate' AND aggregate='EBS Volume Total Iops'
+       | view tile -title "Total EBS Volume Capacity (Iops)";
+      );
+read cloudwatch -from :1 hour ago: -to :now: -period 3600 -statistics ['Maximum'] product='EC2' OR product='ELB' OR product='Lambda'
+  | (filter
+     // EC2: Any instances with failed status checks.
+     (product='EC2' AND (name='StatusCheckFailed_Instance' OR name='StatusCheckFailed_System') AND value=1) OR
+     // ELB: Any load balancers where UnHealthyHostCount is > 0
+     (product='ELB' AND name='UnHealthyHostCount' AND value > 0) OR
+     // Lambda: Any function with errors > 0
+     (product='Lambda' AND name='Errors' AND value > 0))
+  | put oldtime=time
+  | sort time by item
+  | uniq item
+  | put time=oldtime
+  | keep time, product, name, value, item
+  | ( reduce cnt=count()
+      | put level=(cnt == 0 ? 'success' : 'error')
+      | view tile -valueField "cnt" -title "Number of Problem Items (EC2, ELB, Lambda)" -levelField "level";
+      view table -title "Items with problems" -columnOrder ["time", "product", "item", "name", "value"]
+    );
+
+
+

--- a/examples/aws-cloudwatch/overview.juttle
+++ b/examples/aws-cloudwatch/overview.juttle
@@ -23,7 +23,7 @@ read mysql -table 'aws_aggregation' -from :0: -to :end: product='EC2' OR product
        filter product='EBS' AND metric_type='AWS Aggregate' AND aggregate='EBS Volume Total Iops'
        | view tile -title "Total EBS Volume Capacity (Iops)";
       );
-read cloudwatch -from :1 hour ago: -to :now: -period 3600 -statistics ['Maximum'] product='EC2' OR product='ELB' OR product='Lambda'
+read cloudwatch -last :1h: -period 3600 -statistics ['Maximum'] product='EC2' OR product='ELB' OR product='Lambda'
   | (filter
      // EC2: Any instances with failed status checks.
      (product='EC2' AND (name='StatusCheckFailed_Instance' OR name='StatusCheckFailed_System') AND value=1) OR
@@ -31,10 +31,7 @@ read cloudwatch -from :1 hour ago: -to :now: -period 3600 -statistics ['Maximum'
      (product='ELB' AND name='UnHealthyHostCount' AND value > 0) OR
      // Lambda: Any function with errors > 0
      (product='Lambda' AND name='Errors' AND value > 0))
-  | put oldtime=time
-  | sort time by item
-  | uniq item
-  | put time=oldtime
+  | head 1 by item
   | keep time, product, name, value, item
   | ( reduce cnt=count()
       | put level=(cnt == 0 ? 'success' : 'error')

--- a/examples/aws-cloudwatch/poll_aws.juttle
+++ b/examples/aws-cloudwatch/poll_aws.juttle
@@ -1,0 +1,8 @@
+// This juttle program does periodic reads of aws information and writes the results to a mysql database.
+
+import 'https://github.com/juttle/juttle-aws-adapter/raw/master/aws_module.juttle' as Adapter_aws;
+
+read aws -from :now: -to :end: -every :10s:
+     | Adapter_aws.aggregate_all
+     | write mysql -table 'aws_aggregation';
+

--- a/examples/core-juttle/index.juttle
+++ b/examples/core-juttle/index.juttle
@@ -1,5 +1,5 @@
 sub add_juttle(name, description) {
-    put program="[" + name + "](/?path=/examples/core-juttle/" + name + ".juttle)", description=description
+    put program="[${name}](/?path=/examples/core-juttle/${name}.juttle)", description=description
 }
 
 emit |

--- a/examples/elastic-newstracker/index.juttle
+++ b/examples/elastic-newstracker/index.juttle
@@ -1,6 +1,6 @@
 // Output a table with clickable links to the actual demo programs, for navigation.
 sub add_juttle(name, description) {
-    put program="[" + name + "](/?path=/examples/elastic-newstracker/" + name + ".juttle)", description=description
+    put program="[${name}](/?path=/examples/elastic-newstracker/${name}.juttle)", description=description
 }
 
 emit

--- a/examples/gmail/index.juttle
+++ b/examples/gmail/index.juttle
@@ -1,5 +1,5 @@
 sub add_juttle(name, description) {
-    put program="[" + name + "](/?path=/examples/gmail/" + name + ".juttle)", description=description
+    put program="[${name}](/?path=/examples/gmail/${name}.juttle)", description=description
 }
 
 emit |

--- a/examples/index.juttle
+++ b/examples/index.juttle
@@ -10,6 +10,7 @@ emit
     add_subdir_juttle -subdir "gmail" -juttle "index" -description "Examples using gmail adapter";
     add_subdir_juttle -subdir "cadvisor-influx" -juttle "cadvisor-dashboard" -description "Monitor docker containers using cAdvisor and InfluxDB";
     add_subdir_juttle -subdir "postgres-diskstats" -juttle "throughput" -description "Examples joining data from PostgreSQL and file sources";
+    add_subdir_juttle -subdir "aws-cloudwatch" -juttle "index" -description "Examples using AWS/Cloudwatch adapters";
 )
 | keep program, description
 | view table -title 'Example Juttle Programs' -markdownFields [ 'program' ]

--- a/examples/index.juttle
+++ b/examples/index.juttle
@@ -1,5 +1,5 @@
 sub add_subdir_juttle(subdir, juttle, description) {
-    put program="[" + subdir + "](/?path=/examples/" + subdir + "/" + juttle + ".juttle)", description=description
+    put program="[${subdir}](/?path=/examples/${subdir}/${juttle}.juttle)", description=description
 }
 
 emit

--- a/examples/juttle-config.json
+++ b/examples/juttle-config.json
@@ -14,6 +14,14 @@
         },
         "postgres": {
             "connection": "postgres://postgres@postgres/postgres"
+        },
+        "mysql": {
+            "connection": {
+                "user": "root",
+                "password": "my-juttle-password",
+                "host": "examples_mysql_1",
+                "database": "aws"
+            }
         }
     }
 }


### PR DESCRIPTION
This relies on a juttle-engine that has juttle-aws-adapter and juttle-cloudwatch-adapter included. I'll put up a separate PR for that.

Add a collection of example programs for the AWS and Cloudwatch
adapters, copied over from the jut 1.0 built-in boards for the aws
integration.

They are grouped into the following categories:

- overview (overview.juttle): shows the number of EC2 instances, RDS
  total allocated storage, EBS total Iops, as well as a list of
  "problem" items for EC2, ELB, and Lambda.

- demographic (demographic.juttle): show an aggregate as a timechart
  and a demographic as a piechart and timechart for a given product,
  with overlaid events any time the set of items changes.

- capacity_planning/*.juttle: this is broken into multiple programs
  for various products, and provides different ways to combine
  cloudwatch and aws information to give an idea of the reserved
  resources vs resources actually in use.

To make it easier to view aggregate/demographic information across
juttle programs, create a mysql database "aws" with table
"aws_aggregation" and populate it from a juttle program that
periodically fetches aws information, aggregates it using the
aws_module.juttle file (currently pulled directly from github, will
replace with an adapter provided module once juttle/juttle#325 is
fixed), and writes to the mysql database.

dc-aws-cloudwatch.yml contains the mysql container, an additional
mysql container that runs the script to create the database/table, and
an additional juttle-engine container to run the poller juttle
program. The startup of these tasks is a bit hokey with some sleeps to
make sure everything is started in the right order. docker-compose 1.6
claims to support the notion of 'events' where containers can signal
their readiness to each other, but 1.6 was only released days ago so
it's a bit bleeding edge to rely on imho.

Without this, all the example programs take ~10-20 seconds to get any
aws aggregate/demographic information which has to be fetched from
scratch every time a program is run. With the mysql database + poller
script, as long as the docker-compose environment is running you get a
steady stream of updates that can be used across programs.

I'd like to add some cloudwatch-specific programs that allow you to
view cloudwatch-specific metrics, but that's really awkward to use
without inputs with -juttle, so I'll skip that for now.

@dmehra @demmer 
