### PR TITLE
Include aws/cloudwatch in package.

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
     "daemon": "^1.1.0",
     "express": "^4.13.4",
     "juttle": "^0.4.2",
+    "juttle-aws-adapter": "^0.1.3",
+    "juttle-cloudwatch-adapter": "^0.1.2",
     "juttle-elastic-adapter": "^0.4.1",
     "juttle-gmail-adapter": "^0.4.2",
     "juttle-graphite-adapter": "^0.3.1",


### PR DESCRIPTION
Now that aws/cloudwatch are released include them in the package.

@VladVega @dmehra @demmer 