### PR TITLE
Improve aws example programs

### DIFF
--- a/examples/aws-cloudwatch/capacity_planning/autoscaling.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/autoscaling.juttle
@@ -8,7 +8,7 @@
 // more properly match the actual group size.
 //
 
-read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end:
+read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end: -lag :20s:
     product='AutoScaling' AND metric_type='AWS Aggregate' AND
              (aggregate='AutoScaling Group Total Size' OR aggregate='AutoScaling Group Total Desired Capacity')
     | view timechart -keyField "aggregate"

--- a/examples/aws-cloudwatch/capacity_planning/ebs.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/ebs.juttle
@@ -7,8 +7,7 @@
 // want to consider adding more volumes or faster volumes to spread
 // the work across more items.
 
-(read cloudwatch -period 3600 -last :1h: product='EBS'
- | filter name='VolumeReadOps' OR name='VolumeWriteOps'
+(read cloudwatch -period 3600 -last :1h: metric="EBS:VolumeReadOps" OR metric="EBS:VolumeWriteOps"
  | reduce Iops_Used=sum(value)/(3600.0);
  read mysql -table 'aws_aggregation' -last :1h:
    product='EBS' AND aggregate='EBS Volume Total Iops'

--- a/examples/aws-cloudwatch/capacity_planning/ec2.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/ec2.juttle
@@ -22,7 +22,7 @@ const instance_prices = {
     't2.medium': 0.05,
 };
 
-read mysql -table 'aws_aggregation' -from :0: -to :end:
+read mysql -table 'aws_aggregation' -last :1h:
     product='EC2' AND demographic='EC2 Instance Type'
     | put cost=value*instance_prices[name]
     | view piechart -valueField "cost" -title "EC2 Instances Scaled by Hourly Cost" -categoryField "name";

--- a/examples/aws-cloudwatch/capacity_planning/rds.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/rds.juttle
@@ -32,8 +32,7 @@
 
 import "examples/aws-cloudwatch/common/capacity_planning_cpu.juttle" as capacity_cpu;
 
-(read cloudwatch -period 3600 -last :1h: product='RDS'
- | filter (name='ReadIOPS' OR name='WriteIOPS')
+(read cloudwatch -period 3600 -last :1h: metric="RDS:ReadIOPS" OR metric="RDS:WriteIOPS"
  | reduce avg_iops=avg(value) by item, name
  | reduce Iops_Used=sum(avg_iops)
  | keep Iops_Used;
@@ -47,8 +46,7 @@ import "examples/aws-cloudwatch/common/capacity_planning_cpu.juttle" as capacity
  | split
  | view piechart -title "AWS Capacity Planning (Iops) for RDS";
 
-(read cloudwatch -period 3600 -last :1h: product='RDS'
- | filter name='FreeStorageSpace'
+(read cloudwatch -period 3600 -last :1h: metric="RDS:FreeStorageSpace"
  | reduce avg_freespace=avg(value)/(1024*1024*1024) by item
  | reduce Storage_Headroom=sum(avg_freespace);
  read mysql -table 'aws_aggregation' -last :1h:

--- a/examples/aws-cloudwatch/common/capacity_planning_cpu.juttle
+++ b/examples/aws-cloudwatch/common/capacity_planning_cpu.juttle
@@ -11,8 +11,7 @@
 
 export sub cpu_piechart(cw_product) {
 
-    read cloudwatch -period 3600 -last :1h: product=cw_product
-        | filter name='CPUUtilization'
+    read cloudwatch -period 3600 -last :1h: product=cw_product AND metric='CPUUtilization'
         | reduce used_cpu=avg(value)
         | put CPU_Used=used_cpu, CPU_Headroom=100-used_cpu
         | keep CPU_Used, CPU_Headroom

--- a/examples/aws-cloudwatch/create_aws_db.sql
+++ b/examples/aws-cloudwatch/create_aws_db.sql
@@ -7,6 +7,9 @@ CREATE TABLE IF NOT EXISTS aws_aggregation (
        aggregate VARCHAR(128),
        demographic VARCHAR(128),
        metric_type VARCHAR(128),
+       event_type VARCHAR(128),
+       msg VARCHAR(128),
+       item VARCHAR(128),
        product VARCHAR(128),
 
        INDEX aws_metrics_idx (time)

--- a/examples/aws-cloudwatch/demographic.juttle
+++ b/examples/aws-cloudwatch/demographic.juttle
@@ -16,7 +16,7 @@ import "examples/aws-cloudwatch/common/aws_control_aggregate.juttle" as control_
 import "examples/aws-cloudwatch/common/aws_control_demographic.juttle" as control_demo;
 import "examples/aws-cloudwatch/common/aws_control_events.juttle" as control_events;
 
-read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end:
+read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end: -lag :20s:
     | ( filter metric_type='AWS Aggregate' and aggregate=control_agg.agg_in
         | view timechart -keyField "aggregate"
                          -valueField "value"

--- a/examples/aws-cloudwatch/overview.juttle
+++ b/examples/aws-cloudwatch/overview.juttle
@@ -15,7 +15,7 @@
 // - ELB: Any load balancers where UnHealthyHostCount is > 0
 // - Lambda: Any function with errors > 0
 
-read mysql -table 'aws_aggregation' -from :0: -to :end: product='EC2' OR product='EBS' OR product='RDS'
+read mysql -table 'aws_aggregation' -from :0: -to :end: -lag :20s: product='EC2' OR product='EBS' OR product='RDS'
     | (filter product='EC2' AND metric_type='AWS Aggregate' AND aggregate='EC2 Instance Count'
        | view tile -title "Number of EC2 Instances";
        filter product='RDS' AND metric_type='AWS Aggregate' AND aggregate='RDS DB Total Allocated Storage'
@@ -23,14 +23,17 @@ read mysql -table 'aws_aggregation' -from :0: -to :end: product='EC2' OR product
        filter product='EBS' AND metric_type='AWS Aggregate' AND aggregate='EBS Volume Total Iops'
        | view tile -title "Total EBS Volume Capacity (Iops)";
       );
-read cloudwatch -last :1h: -period 3600 -statistics ['Maximum'] product='EC2' OR product='ELB' OR product='Lambda'
+read cloudwatch -last :1h: -period 3600 -statistics ['Maximum'] metric='EC2:StatusCheckFailed_Instance' OR
+                                                                metric='EC2:StatusCheckFailed_System' OR
+                                                                metric='ELB:UnHealthyHostCount' OR
+                                                                metric='Lambda:Errors'
   | (filter
      // EC2: Any instances with failed status checks.
-     (product='EC2' AND (name='StatusCheckFailed_Instance' OR name='StatusCheckFailed_System') AND value=1) OR
+     (product='EC2' AND value=1) OR
      // ELB: Any load balancers where UnHealthyHostCount is > 0
-     (product='ELB' AND name='UnHealthyHostCount' AND value > 0) OR
+     (product='ELB' AND value > 0) OR
      // Lambda: Any function with errors > 0
-     (product='Lambda' AND name='Errors' AND value > 0))
+     (product='Lambda' AND value > 0))
   | head 1 by item
   | keep time, product, name, value, item
   | ( reduce cnt=count()


### PR DESCRIPTION
This relies on the changes in juttle/juttle-cloudwatch-adapter#5, which add support for specifying metrics in read cloudwatch filtering expressions. The cloudwatch-related pages now load much more quickly.

Once this is merged I'll get it running on demo.juttle.io.

@VladVega @go-oleg @davidvgalbraith 