### PR TITLE
Rendezvous msg validation

### DIFF
--- a/bin/juttle-engine-client
+++ b/bin/juttle-engine-client
@@ -28,7 +28,21 @@ function push_file(filename, topic) {
             bundler.bundle(filename)
                 .then(function(bundle) {
                     return new Promise(function (resolve, reject) {
-                        ws.send(JSON.stringify(bundle), resolve);
+                        ws.on('message', (data) => {
+                            data = JSON.parse(data);
+
+                            if (data.type === 'error') {
+                                reject(data.error);
+                            } else {
+                                resolve();
+                            }
+                        })
+
+                        ws.send(JSON.stringify({
+                            type: 'bundle',
+                            bundle_id: filename,
+                            bundle
+                        }));
                     });
                 })
                 .catch(function(err) {

--- a/lib/bundle-notifier.js
+++ b/lib/bundle-notifier.js
@@ -13,7 +13,7 @@ var errors = require('./errors');
 // juttle-engine-client and the corresponding '?rendezvous=<topic>
 // urls in the viewer.
 
-class EndpointNotifier {
+class BundleNotifier {
 
     constructor(options) {
         // Maps from topic to a list of endpoints who are interested
@@ -86,4 +86,4 @@ class EndpointNotifier {
     }
 }
 
-module.exports = EndpointNotifier;
+module.exports = BundleNotifier;

--- a/lib/endpoint-notifier.js
+++ b/lib/endpoint-notifier.js
@@ -3,6 +3,8 @@ var _ = require('underscore');
 var getLogger = require('juttle-service').getLogger;
 var logger = getLogger('endpoint-notifier');
 
+var errors = require('./errors');
+
 // The EndpointNotifier manages rendezvous between multiple clients
 // connecting via websockets. It is a simple echo server, passing any
 // message sent from any client to all other clients.
@@ -37,8 +39,23 @@ class EndpointNotifier {
         });
 
         endpoint.events.on('message', (data) => {
-            this._last_message = data;
-            this.broadcast(topic, data);
+            try {
+                if (!data.bundle || !data.bundle_id || !data.type) {
+                    throw errors.topicMsgError(data);
+                }
+
+                this._last_message = data;
+                this.broadcast(topic, data);
+            } catch (err) {
+                logger.error('Error send topic message:', err.message);
+                endpoint.send({
+                    type: 'error',
+                    error: {
+                        code: err.code,
+                        message: err.message
+                    }
+                });
+            }
         });
 
         if (this._last_message) {

--- a/lib/errors.js
+++ b/lib/errors.js
@@ -1,0 +1,41 @@
+'use strict';
+let _ = require('underscore');
+
+let messages = require('./strings/juttle-engine-error-strings-en-US.json');
+
+class BaseError extends Error {
+    constructor(code, info) {
+        super();
+
+        if (Error.captureStackTrace) {
+            Error.captureStackTrace(this, this.constructor);
+        }
+
+        this.code = code;
+        this.info = info;
+
+        let template = _.template(messages[this.code], {
+            interpolate: /\{\{[^#\{]([\s\S]+?)[^\}]\}\}/g,
+            evaluate: /\{\{\#([\s\S]+?)\}\}/g,
+            variable: 'info'
+        });
+
+        this.message = template(info);
+    }
+}
+
+class TopicMsgError extends BaseError {
+    constructor(info) {
+        super('JE-INVALID-TOPIC-MSG', info);
+    }
+}
+
+let errors = {};
+
+errors.topicMsgError = function(data) {
+    return new TopicMsgError({
+        missing_keys: _.difference(['bundle_id', 'bundle', 'type'], _.keys(data)).join(', ')
+    });
+}
+
+module.exports = errors;

--- a/lib/juttle-engine.js
+++ b/lib/juttle-engine.js
@@ -11,16 +11,10 @@ var EndpointNotifier = require('./endpoint-notifier');
 
 var app, server;
 
-var endpoint_notifier = new EndpointNotifier();
-
-function rendezvous_topic(ws, req) {
-    var ep = new WebsocketEndpoint({ws: ws});
-    endpoint_notifier.add_endpoint_to_topic(ep, req.params.topic);
-}
-
 function run(opts, ready) {
     logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-engine.log'}));
     var logger = getLogger('juttle-engine')
+    var endpoint_notifier = new EndpointNotifier();
 
     if (opts.daemonize) {
         daemonize();
@@ -48,8 +42,10 @@ function run(opts, ready) {
     app.use(viewer(viewerOpts));
 
     // Also add routes for rendezvous.
-    app.ws('/rendezvous/:topic',
-           rendezvous_topic);
+    app.ws('/rendezvous/:topic', (ws, req) => {
+        var ep = new WebsocketEndpoint({ws: ws});
+        endpoint_notifier.add_endpoint_to_topic(ep, req.params.topic);
+    });
 
     var listenAddr = opts.host || '0.0.0.0';
     server = app.listen(opts.port, listenAddr, () => {

--- a/lib/juttle-engine.js
+++ b/lib/juttle-engine.js
@@ -7,14 +7,14 @@ var getLogger = require('juttle-service').getLogger;
 var WebsocketEndpoint = require('juttle-service').WebsocketEndpoint;
 var viewer = require('juttle-viewer');
 var daemonize = require('daemon');
-var EndpointNotifier = require('./endpoint-notifier');
+var BundleNotifier = require('./bundle-notifier');
 
 var app, server;
 
 function run(opts, ready) {
     logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-engine.log'}));
     var logger = getLogger('juttle-engine')
-    var endpoint_notifier = new EndpointNotifier();
+    var bundle_notifier = new BundleNotifier();
 
     if (opts.daemonize) {
         daemonize();
@@ -44,7 +44,7 @@ function run(opts, ready) {
     // Also add routes for rendezvous.
     app.ws('/rendezvous/:topic', (ws, req) => {
         var ep = new WebsocketEndpoint({ws: ws});
-        endpoint_notifier.add_endpoint_to_topic(ep, req.params.topic);
+        bundle_notifier.add_endpoint_to_topic(ep, req.params.topic);
     });
 
     var listenAddr = opts.host || '0.0.0.0';

--- a/lib/juttle-engine.js
+++ b/lib/juttle-engine.js
@@ -1,5 +1,6 @@
 'use strict';
 var _ = require('underscore');
+var Promise = require('bluebird');
 var express = require('express');
 var service = require('juttle-service').service;
 var logSetup = require('juttle-service').logSetup;
@@ -56,7 +57,9 @@ function run(opts, ready) {
 }
 
 function stop() {
-    server.close();
+    return new Promise((resolve, reject) => {
+        server.close(resolve);
+    });
 }
 
 module.exports = {

--- a/lib/strings/juttle-engine-error-strings-en-US.json
+++ b/lib/strings/juttle-engine-error-strings-en-US.json
@@ -1,0 +1,3 @@
+{
+    "JE-INVALID-TOPIC-MSG": "Topic request body is missing the following params: {{ info.missing_keys }}"
+}

--- a/test/juttle-engine-bin.spec.js
+++ b/test/juttle-engine-bin.spec.js
@@ -22,7 +22,7 @@ describe('juttle-engine-client binary', function() {
     });
 
     after(function() {
-        engine.stop();
+        return engine.stop();
     });
 
     it('can be run with --help', function() {

--- a/test/juttle-engine.spec.js
+++ b/test/juttle-engine.spec.js
@@ -25,6 +25,18 @@ describe('Juttle Engine Tests', function() {
     });
 
     describe('Rendezvous tests', function() {
+        let listener, sender;
+
+        afterEach(() => {
+            if (listener) {
+                listener.close();
+            }
+
+            if (sender) {
+                sender.close();
+            }
+        });
+
         it('Listen to a topic, can receive messages sent by other clients ', function(done) {
             const validMsg = {
                 type: 'bundle',
@@ -35,7 +47,7 @@ describe('Juttle Engine Tests', function() {
                 }
             };
 
-            let listener = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
+            listener = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
             listener.on('message', function(data) {
                 data = JSON.parse(data);
                 expect(data).to.deep.equal(validMsg);
@@ -44,7 +56,7 @@ describe('Juttle Engine Tests', function() {
             });
 
             listener.on('open', function() {
-                let sender = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
+                sender = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
 
                 sender.on('open', function() {
                     sender.send(JSON.stringify(validMsg));
@@ -61,9 +73,9 @@ describe('Juttle Engine Tests', function() {
                 }
             };
 
-            let listener = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
+            listener = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
             listener.on('open', () => {
-                let sender = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
+                sender = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
 
                 sender.on('open', () => {
                     sender.send(JSON.stringify(invalidMsg));

--- a/test/juttle-engine.spec.js
+++ b/test/juttle-engine.spec.js
@@ -8,7 +8,7 @@ var findFreePort = Promise.promisify(require('find-free-port'));
 describe('Juttle Engine Tests', function() {
     var juttleHostPort;
 
-    before(function() {
+    beforeEach(function() {
         findFreePort(10000, 20000)
             .then((freePort) => {
                 juttleHostPort = 'http://localhost:' + freePort;
@@ -20,29 +20,65 @@ describe('Juttle Engine Tests', function() {
             });
     });
 
-    after(function() {
+    afterEach(function() {
         engine.stop();
     });
 
     describe('Rendezvous tests', function() {
         it('Listen to a topic, can receive messages sent by other clients ', function(done) {
-            var listener = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
+            const validMsg = {
+                type: 'bundle',
+                bundle_id: 'valid-bundle',
+                bundle: {
+                    program: 'emit',
+                    modules: []
+                }
+            };
 
+            let listener = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
             listener.on('message', function(data) {
                 data = JSON.parse(data);
-                if (data.type === 'message') {
-                    expect(data.message).to.equal('my-message');
-                    listener.close();
-                    done();
-                }
+                expect(data).to.deep.equal(validMsg);
+                listener.close();
+                done();
             });
 
             listener.on('open', function() {
-                var sender = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
+                let sender = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
 
                 sender.on('open', function() {
-                    sender.send(JSON.stringify({type: 'message', message: 'my-message'}));
+                    sender.send(JSON.stringify(validMsg));
                     sender.close();
+                });
+            });
+        });
+
+        it('Recieves error on invalid message', (done) => {
+            const invalidMsg = {
+                bundle: {
+                    program: 'emit',
+                    modules: []
+                }
+            };
+
+            let listener = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
+            listener.on('open', () => {
+                let sender = new WebSocket(juttleHostPort + '/rendezvous/my-topic');
+
+                sender.on('open', () => {
+                    sender.send(JSON.stringify(invalidMsg));
+                });
+
+                sender.on('message', (data) => {
+                    data = JSON.parse(data);
+                    expect(data).to.deep.equal({
+                        'type': 'error',
+                        'error': {
+                            code: 'JE-INVALID-TOPIC-MSG',
+                            message: 'Topic request body is missing the following params: bundle_id, type'
+                        }
+                    });
+                    done();
                 });
             });
         });


### PR DESCRIPTION
On the client end of things we need to ensure that every topic msg
includes a bundle_id along with the bundle_object. The bundle_id is used
to tell whether the incoming message is an update to a bundle or a new
bundle altogehter. All this effects the way we run the bundle and its
inputs.

Added validation to topic msgs to ensure that `bundle`, `bundle_id`, and
`type` are included in any client requests. If not, an error message is
returned to the sending client.

Also fixed issue with EndpointNotifier persisting in between engine runs
(see commit for details).