### PR TITLE
Add a dockerfile that builds from source.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM node:4.2.4-wheezy
+MAINTAINER Mark Stemm (mstemm@jut.io)
+
+RUN mkdir -p /opt/juttle-engine
+WORKDIR /opt/juttle-engine
+ADD package.json package.json
+RUN npm install
+COPY . .
+
+RUN mkdir -p /opt/juttle-engine/juttles
+COPY examples /opt/juttle-engine/juttles/examples
+
+# Also symlink juttle and juttle-engine so they can be run directly
+# without specifying a path.
+RUN ln -s /opt/juttle-engine/bin/juttle /usr/local/bin/juttle
+RUN ln -s /opt/juttle-engine/bin/juttle-engine /usr/local/bin/juttle-engine
+
+
+EXPOSE 8080
+
+CMD /opt/juttle-engine/bin/juttle-engine --root /opt/juttle-engine/juttles

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,11 +10,7 @@ COPY . .
 RUN mkdir -p /opt/juttle-engine/juttles
 COPY examples /opt/juttle-engine/juttles/examples
 
-# Also symlink juttle and juttle-engine so they can be run directly
-# without specifying a path.
-RUN ln -s /opt/juttle-engine/bin/juttle /usr/local/bin/juttle
-RUN ln -s /opt/juttle-engine/bin/juttle-engine /usr/local/bin/juttle-engine
-
+RUN npm link
 
 EXPOSE 8080
 


### PR DESCRIPTION
Add a Dockerfile that builds from a checked out tree, loosely
following the steps implied by
https://github.com/nodejs/docker-node/blob/master/4.3/onbuild/Dockerfile:

 - copy package.json to image
 - run npm install within image
 - copy source code to image

Continue to use /opt/juttle-engine/juttles as the root for consistency with
the released image.

This npm install does not install globally, so symlink
juttle/juttle-engine to /usr/local/bin so they can be run without a
path.

This PR also bumps the juttle-cloudwatch-adapter to version 0.2.0. I
can pull that out into a separate PR if necessary.

I've also set up automated builds from docker hub for the juttle-engine repo. There's even one there right now for this branch! https://hub.docker.com/r/juttle/juttle-engine-canary/tags/

By default the branch name will be used as the tag.

@rlgomes @mnibecker 