### PR TITLE
Add example programs for reading nginx logs.

### DIFF
--- a/examples/juttle-config.json
+++ b/examples/juttle-config.json
@@ -5,6 +5,11 @@
                 "id": "local",
                 "address": "examples_elasticsearch_1",
                 "port": 9200
+            },
+            {
+                "id": "nginx",
+                "address": "examples_elasticsearch-nginx_1",
+                "port": 9200
             }
         ],
         "influx": {

--- a/examples/nginx_logs/README.md
+++ b/examples/nginx_logs/README.md
@@ -1,0 +1,55 @@
+# Example programs using nginx and elasticsearch
+
+## Description
+The programs below this directory are mostly for internal use and
+can't be used on their own in an isolated docker-compose environment,
+so they're aren't described in the overall examples README. However,
+here's a quick description of how they work.
+
+## Additional docker-compose configuration
+
+These programs parse the contents of /var/log/nginx/access.log into an
+elasticsearch instance using
+logstash. [dc-nginx-logs.yml](./dc-nginx-logs.yml) adds the following
+containers:
+
+- elasticsearch-nginx: an elasticsearch instance to hold parsed nginx contents
+- logstash-nginx: a logstash instance that parses `/var/log/nginx/access.log` (mapped within the container as `/incoming/nginx-access.log`) and sends the parsed contents to elasticsearch
+
+Logstash monitors the file for new contents and parses the new contents when necessary.
+
+## ``juttle-config.json`` configuration
+
+Add the following section to `.juttle-config.json` to add a second elasticsearch instance:
+
+```
+{
+    "adapters": {
+        "elastic": [
+            {
+                "id": "nginx",
+                "address": "examples_elasticsearch-nginx_1",
+                "port": 9200
+            }
+        ]
+    }
+}
+```
+
+## Juttle Programs
+
+`nginx-elastic.juttle` reads the last day's worth of parsed nginx logs and breaks down the requests by:
+
+- examples subdirectory
+- browser name
+- browser OS
+- Ip address
+- The city for the ip address (using the geoip capabilities within logstash)
+- requests by response code
+
+
+
+
+
+
+

--- a/examples/nginx_logs/dc-nginx-logs.yml
+++ b/examples/nginx_logs/dc-nginx-logs.yml
@@ -1,0 +1,20 @@
+elasticsearch-nginx:
+  container_name: examples_elasticsearch-nginx_1
+  image: elasticsearch:2.1.1
+
+logstash-nginx:
+  image: logstash:2.1.1
+  links:
+    -  elasticsearch-nginx
+  volumes:
+    - /var/log/nginx/access.log:/incoming/nginx-access.log:ro
+    - ${PWD}/nginx_logs/logstash.conf:/config/logstash.conf
+  command: bash -c "adduser logstash adm && logstash -f /config/logstash.conf"
+
+juttle-engine:
+  links:
+    - elasticsearch-nginx
+  external_links:
+    - examples_elasticsearch-nginx_1
+
+

--- a/examples/nginx_logs/logstash.conf
+++ b/examples/nginx_logs/logstash.conf
@@ -1,0 +1,42 @@
+input {
+  file {
+    path => '/incoming/nginx-access.log'
+    start_position => 'beginning'
+  }
+}
+filter {
+  grok {
+    match => [ "message" , "%{COMBINEDAPACHELOG}+%{GREEDYDATA:extra_fields}"]
+    overwrite => [ "message" ]
+  }
+
+  mutate {
+    convert => ["response", "integer"]
+    convert => ["bytes", "integer"]
+    convert => ["responsetime", "float"]
+  }
+
+  geoip {
+    source => "clientip"
+    target => "geoip"
+    add_tag => [ "nginx-geoip" ]
+  }
+
+  date {
+    match => [ "timestamp" , "dd/MMM/YYYY:HH:mm:ss Z" ]
+    remove_field => [ "timestamp" ]
+  }
+
+  useragent {
+    source => "agent"
+  }
+  dns {
+    reverse => [ "clientip"]
+    action => "replace"
+  }
+}
+output {
+  elasticsearch {
+    hosts => "elasticsearch-nginx"
+  }
+}

--- a/examples/nginx_logs/nginx-elastic.juttle
+++ b/examples/nginx_logs/nginx-elastic.juttle
@@ -9,7 +9,7 @@ read elastic -from :1 day ago: -to :now: -id 'nginx' |
 
 //    view table -limit 10;
 
-    // Requests by Browser Name
+    // Requests by examples request area
     filter request ~ /^\/api\/v0\/path/ | put request = String.replace(request, '/api/v0/paths', '') | reduce count=count() by request | sort count -desc | view barchart -title "Breakdown by Request";
 
     // Requests by Browser Name

--- a/examples/nginx_logs/nginx-elastic.juttle
+++ b/examples/nginx_logs/nginx-elastic.juttle
@@ -1,0 +1,31 @@
+export input show_local_in: select
+    -label 'Show Local Traffic'
+    -items [{label: 'Yes', value: "*"}, {label: 'No', value: "Impossible"} ]
+    -default '*';
+
+read elastic -from :1 day ago: -to :now: -id 'nginx' |
+    filter clientip !~ /regus/ OR clientip ~ show_local_in |
+(
+
+//    view table -limit 10;
+
+    // Requests by Browser Name
+    filter request ~ /^\/api\/v0\/path/ | put request = String.replace(request, '/api/v0/paths', '') | reduce count=count() by request | sort count -desc | view barchart -title "Breakdown by Request";
+
+    // Requests by Browser Name
+    reduce count=count() by name | sort count -desc | view barchart -title "Breakdown by Browser";
+
+    // Requests by OS
+    reduce count=count() by os_name | sort count -desc | view barchart -title "Breakdown by OS";
+
+    // Requests by IP
+    reduce count=count() by clientip | sort count -desc | view barchart -title "Breakdown by IP";
+
+    // Requests by City
+    put city=geoip['city_name'] | filter city != null | reduce count=count() by city | sort count -desc | view barchart -title 'Breakdown by City' -categoryField 'city' -valueField 'count';
+
+    // Requests by response code
+    reduce count=count() by response | sort count -desc | view barchart -title "Breakdown by HTTP Response Code" -categoryField 'response' -valueField 'count';
+)
+
+


### PR DESCRIPTION
Add example programs and docker-compose files that show how to read
nginx logs using logstash, save the parsed results in elasticsearch,
and summarize the parsed results in juttle programs.

I am checking the programs in, but I'm not including them in the
examples README or providing a standalong README for now, as the
program seems pretty specific to our situation. Maybe we need another
repository/location just for internal-facing programs and supporting
infrastructure?

@demmer @philrz @davidvgalbraith 