### PR TITLE
Add thresholding to pie charts.

### DIFF
--- a/examples/aws-cloudwatch/capacity_planning/ec2.juttle
+++ b/examples/aws-cloudwatch/capacity_planning/ec2.juttle
@@ -22,9 +22,22 @@ const instance_prices = {
     't2.medium': 0.05,
 };
 
-read mysql -table 'aws_aggregation' -last :1h:
+// Take categories contributing less than x percent to the total and
+// group them together in an "Other" category.
+sub threshold(thresh) {
+    (reduce total=sum(cost); pass)
+    | join
+    | put pct = 100.0*cost/total
+    | put name=(pct >= thresh ? name : 'other')
+    | reduce cost=sum(cost), time=last(time) by name
+    | sort name
+}
+
+read mysql -table 'aws_aggregation' -last :10m:
     product='EC2' AND demographic='EC2 Instance Type'
     | put cost=value*instance_prices[name]
+    | batch -every :1s:
+    | threshold -thresh 2
     | view piechart -valueField "cost" -title "EC2 Instances Scaled by Hourly Cost" -categoryField "name";
 
 

--- a/examples/aws-cloudwatch/demographic.juttle
+++ b/examples/aws-cloudwatch/demographic.juttle
@@ -16,6 +16,17 @@ import "examples/aws-cloudwatch/common/aws_control_aggregate.juttle" as control_
 import "examples/aws-cloudwatch/common/aws_control_demographic.juttle" as control_demo;
 import "examples/aws-cloudwatch/common/aws_control_events.juttle" as control_events;
 
+// Take categories contributing less than x percent to the total and
+// group them together in an "Other" category.
+sub threshold(thresh) {
+    (reduce total=sum(value); pass)
+    | join
+    | put pct = 100.0*value/total
+    | put name=(pct >= thresh ? name : 'other')
+    | reduce value=sum(value), time=last(time) by name
+    | sort name
+}
+
 read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end: -lag :20s:
     | ( filter metric_type='AWS Aggregate' and aggregate=control_agg.agg_in
         | view timechart -keyField "aggregate"
@@ -31,6 +42,8 @@ read mysql -table 'aws_aggregation' -from :1 hour ago: -to :end: -lag :20s:
                       -messageField "item"
                       -typeField "icon";
        filter metric_type='AWS Demographic' AND demographic=control_demo.demo_in
+       | batch -every :1s:
+       | threshold -thresh 2
        | view piechart -categoryField "name"
                        -valueField "value"
                        -title "AWS Demographics (${control_demo.demo_in})";

--- a/examples/aws-cloudwatch/demographic.juttle
+++ b/examples/aws-cloudwatch/demographic.juttle
@@ -23,7 +23,7 @@ sub threshold(thresh) {
     | join
     | put pct = 100.0*value/total
     | put name=(pct >= thresh ? name : 'other')
-    | reduce value=sum(value), time=last(time) by name
+    | reduce value=sum(value) by name
     | sort name
 }
 


### PR DESCRIPTION
Based on review of the aws blog post, add thresholding to pie charts
to example programs to group together low volume categories into an
other category.

@davidvgalbraith 