### PR TITLE
enable postgres example tests

### DIFF
--- a/test/examples/examples.spec.js
+++ b/test/examples/examples.spec.js
@@ -92,7 +92,8 @@ describe('examples', () => {
 
     _.each({
         'core-juttle': 'examples/core-juttle',
-        'cadvisor-influx': 'examples/cadvisor-influx/'
+        'cadvisor-influx': 'examples/cadvisor-influx/',
+        'postgres-diskstats': 'examples/postgres-diskstats/'
     }, (directory, name) => {
         let juttles = fs.readdirSync(directory);
         juttles = juttles.filter((file) => {

--- a/test/examples/start-example-containers.sh
+++ b/test/examples/start-example-containers.sh
@@ -7,14 +7,17 @@ pushd examples
 
 docker-compose -f dc-juttle-engine.yml \
                -f cadvisor-influx/dc-cadvisor-influx.yml \
+               -f postgres-diskstats/dc-postgres.yml \
                stop
 
 docker-compose -f dc-juttle-engine.yml \
                -f cadvisor-influx/dc-cadvisor-influx.yml \
+               -f postgres-diskstats/dc-postgres.yml \
                rm -f
 
 docker-compose -f dc-juttle-engine.yml \
                -f cadvisor-influx/dc-cadvisor-influx.yml \
+               -f postgres-diskstats/dc-postgres.yml \
                up -d
 
 popd

--- a/test/examples/stop-example-containers.sh
+++ b/test/examples/stop-example-containers.sh
@@ -7,10 +7,12 @@ pushd examples
 
 docker-compose -f dc-juttle-engine.yml \
                -f cadvisor-influx/dc-cadvisor-influx.yml \
+               -f postgres-diskstats/dc-postgres.yml \
                stop
 
 docker-compose -f dc-juttle-engine.yml \
                -f cadvisor-influx/dc-cadvisor-influx.yml \
+               -f postgres-diskstats/dc-postgres.yml \
                rm -f
 
 popd


### PR DESCRIPTION
fixes #67

with this docker will pick a random host port and allows us to verify
the postgres-diskstats juttles