### PR TITLE
let docker choose the host port

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -201,3 +201,34 @@ mounts of paths below /tmp will refer to the VM and not your Mac/etc
 host. See
 [this github page](https://github.com/docker/compose/issues/1039) for
 more details.
+
+### Development & Debugging
+
+By default the `docker-compose` files expose the underlying data source
+ports by choosing a random host port. You may want to connect directly to
+the exposed port to diagnose problems and debug juttle programs. To see which
+ports are exposed, you can use `docker-compose` like so:
+
+```
+> docker-compose -f dc-juttle-engine.yml -f aws-cloudwatch/dc-aws-cloudwatch.yml -f cadvisor-influx/dc-cadvisor-influx.yml -f elastic-newstracker/dc-elastic-loadfromscratch.yml -f nginx_logs/dc-nginx-logs.yml -f postgres-diskstats/dc-postgres.yml ps
+Name                            Command               State                                   Ports
+------------------------------------------------------------------------------------------------------------------------------------------------
+examples_cadvisor_1               /usr/bin/cadvisor -logtost ...   Up       0.0.0.0:32776->8080/tcp
+examples_elasticsearch-nginx_1    /docker-entrypoint.sh elas ...   Up       0.0.0.0:32777->9200/tcp, 9300/tcp
+examples_elasticsearch_1          /docker-entrypoint.sh elas ...   Up       0.0.0.0:32778->9200/tcp, 9300/tcp
+examples_influxdb_1               /run.sh                          Up       0.0.0.0:32775->8083/tcp, 0.0.0.0:32774->8086/tcp, 8090/tcp, 8099/tcp
+examples_juttle-aws-poller_1      bash -c sleep 40 && echo ' ...   Up       8080/tcp
+examples_juttle-engine_1          /bin/sh -c /opt/juttle-eng ...   Up       0.0.0.0:8080->8080/tcp
+examples_juttle-engine_loader_1   bash /config/loadfromscrat ...   Up       8080/tcp
+examples_logstash-nginx_1         /docker-entrypoint.sh bash ...   Up
+examples_logstash_1               /docker-entrypoint.sh bash ...   Exit 0
+examples_mysql-createdb_1         /entrypoint.sh bash -c sle ...   Up       3306/tcp
+examples_mysql_1                  /entrypoint.sh mysqld            Up       0.0.0.0:32779->3306/tcp
+examples_postgres_1               /docker-entrypoint.sh postgres   Up       0.0.0.0:32780->5432/tcp
+examples_postgres_data_1          /bin/sh -c tail -f /dev/null     Up
+```
+
+As you can see above the instance for the `postgres-diskstats` example has the
+**postgres** database listening on the host at port `32780` which means you can
+connect to that **postgres** instance listening on that port to see what is
+actually stored int that **postgres** instance.

--- a/examples/aws-cloudwatch/dc-aws-cloudwatch.yml
+++ b/examples/aws-cloudwatch/dc-aws-cloudwatch.yml
@@ -12,6 +12,8 @@ mysql:
     - MYSQL_ROOT_PASSWORD=my-juttle-password
   command:
     - mysqld
+  ports:
+    - 3306
 
 juttle-engine:
   links:

--- a/examples/cadvisor-influx/dc-cadvisor-influx.yml
+++ b/examples/cadvisor-influx/dc-cadvisor-influx.yml
@@ -2,18 +2,18 @@ influxdb:
   container_name: examples_influxdb_1
   image: tutum/influxdb:latest
   ports:
-    - "8083:8083"
-    - "8086:8086"
+    - 8083
+    - 8086
   expose:
-    - "8090"
-    - "8099"
+    - 8090
+    - 8099
   environment:
     - PRE_CREATE_DB=cadvisor
 cadvisor:
   image: google/cadvisor:latest
   command: -storage_driver=influxdb -storage_driver_db=cadvisor -storage_driver_host=influxdb:8086 -logtostderr=true -v=9 -stderrthreshold=9 -storage_driver_buffer_duration=2s
   ports:
-    - "8081:8080"
+    - 8080
   volumes:
     - /:/rootfs:ro
     - /var/run:/var/run:rw

--- a/examples/elastic-newstracker/dc-elastic-loadfromscratch.yml
+++ b/examples/elastic-newstracker/dc-elastic-loadfromscratch.yml
@@ -7,7 +7,7 @@ elasticsearch:
 #  volumes_from:
 #    - elastic_news_data
   ports:
-    - 9200:9200
+    - 9200
 
 logstash:
   image: logstash:2.1.1
@@ -21,4 +21,3 @@ logstash:
 juttle-engine:
   links:
     - elasticsearch
-

--- a/examples/elastic-newstracker/dc-elastic.yml
+++ b/examples/elastic-newstracker/dc-elastic.yml
@@ -7,11 +7,10 @@ elasticsearch:
   volumes_from:
     - elastic_news_data
   ports:
-    - 9200:9200
+    - 9200
 
 juttle-engine:
   links:
     - elasticsearch
   external_links:
     - examples_elasticsearch_1
-

--- a/examples/nginx_logs/dc-nginx-logs.yml
+++ b/examples/nginx_logs/dc-nginx-logs.yml
@@ -1,6 +1,8 @@
 elasticsearch-nginx:
   container_name: examples_elasticsearch-nginx_1
   image: elasticsearch:2.1.1
+  ports:
+    - 9200
 
 logstash-nginx:
   image: logstash:2.1.1
@@ -16,5 +18,3 @@ juttle-engine:
     - elasticsearch-nginx
   external_links:
     - examples_elasticsearch-nginx_1
-
-

--- a/examples/postgres-diskstats/dc-postgres.yml
+++ b/examples/postgres-diskstats/dc-postgres.yml
@@ -5,7 +5,7 @@ postgres:
   container_name: examples_postgres_1
   image: postgres
   ports:
-    - 5432:5432
+    - 5432
 
 juttle-engine_loader:
 # this container will load data into postgres via juttle, and exit.


### PR DESCRIPTION
per discussion on #68

we want the ports to get auto assigned by docker which would remove any
port collision issues

also added a documentation section on `Development & Debugging` which
lets others how to figure out what port got assigned per container.