### PR TITLE
Make poll_aws.juttle a shell script.

### DIFF
--- a/examples/aws-cloudwatch/dc-aws-cloudwatch.yml
+++ b/examples/aws-cloudwatch/dc-aws-cloudwatch.yml
@@ -41,5 +41,6 @@ juttle-aws-poller:
      - mysql
   volumes:
      - ${PWD}/juttle-config.json:/opt/juttle-engine/.juttle-config.json
-     - ${PWD}/aws-cloudwatch/poll_aws.juttle.skip:/opt/juttle-engine/poll_aws.juttle
-  command: bash -c "sleep 40 && echo 'Polling from AWS and Writing to Mysql...' && juttle /opt/juttle-engine/poll_aws.juttle"
+     - ${PWD}/aws-cloudwatch/poll_aws.sh:/opt/juttle-engine/poll_aws.sh
+  command: bash /opt/juttle-engine/poll_aws.sh
+

--- a/examples/aws-cloudwatch/poll_aws.juttle.skip
+++ b/examples/aws-cloudwatch/poll_aws.juttle.skip
@@ -1,8 +1,0 @@
-// This juttle program does periodic reads of aws information and writes the results to a mysql database.
-
-import 'https://github.com/juttle/juttle-aws-adapter/raw/master/aws_module.juttle' as Adapter_aws;
-
-read aws -from :now: -to :end: -every :10s:
-     | Adapter_aws.aggregate_all
-     | write mysql -table 'aws_aggregation';
-

--- a/examples/aws-cloudwatch/poll_aws.sh
+++ b/examples/aws-cloudwatch/poll_aws.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# This juttle program does periodic reads of aws information and writes the results to a mysql database.
+
+sleep 40;
+
+echo 'Polling from AWS and Writing to Mysql...';
+
+juttle -e "
+
+import 'https://github.com/juttle/juttle-aws-adapter/raw/master/aws_module.juttle' as AWS;
+
+read aws -from :now: -to :end: -every :10s:
+     | AWS.aggregate_all
+     | write mysql -table 'aws_aggregation';
+
+" && tail -f /dev/null

--- a/examples/aws-cloudwatch/poll_aws.sh
+++ b/examples/aws-cloudwatch/poll_aws.sh
@@ -14,4 +14,6 @@ read aws -from :now: -to :end: -every :10s:
      | AWS.aggregate_all
      | write mysql -table 'aws_aggregation';
 
-" && tail -f /dev/null
+";
+
+tail -f /dev/null

--- a/examples/aws-cloudwatch/poll_aws.sh
+++ b/examples/aws-cloudwatch/poll_aws.sh
@@ -16,4 +16,6 @@ read aws -from :now: -to :end: -every :10s:
 
 ";
 
+echo 'juttle poller unexpectedly exited';
+
 tail -f /dev/null


### PR DESCRIPTION
Rename poll_aws.juttle.skip to poll_aws.sh so it won't be exposed in
the file explorer.

Also, move the sleep/echo into that script.

@demmer this is what we discussed earlier.