### PR TITLE
add option to override the index path

### DIFF
--- a/bin/juttle-engine
+++ b/bin/juttle-engine
@@ -20,6 +20,7 @@ var possible_opts = {
     o: 'output',
     L: 'log-config',
     l: 'log-level',
+    i: 'index-path',
     h: 'help'
 };
 
@@ -35,6 +36,7 @@ function usage() {
     console.log('       -o, --output <logfile>:                Log to specififed file when daemonized');
     console.log('       -L, --log-config <log4js-config-path>: Configure logging from <log4js-config-path>. Overrides any value of -o');
     console.log('       -l, --log-level <level>:               Use a default log level of <level>. Overridden by any log level specified in -L');
+    console.log('       -i, --index-path <path>:               Serve the given file as the main application page instead of the juttle-viewer default');
     console.log('       -h, --help:                            Print this help and exit');
     process.exit(1);
 }

--- a/lib/juttle-engine.js
+++ b/lib/juttle-engine.js
@@ -39,7 +39,9 @@ function run(opts, ready) {
 
     service.addRoutes(app, service_opts);
 
-    let viewerOpts = {};
+    let viewerOpts = {
+        indexPath: opts['index-path']
+    };
     if (opts.host) {
         viewerOpts.juttleServiceHost = opts.host + ':' + opts.port;
     }

--- a/package.json
+++ b/package.json
@@ -65,8 +65,10 @@
     "gulp-mocha": "^2.2.0",
     "isparta": "^4.0.0",
     "mocha-logger": "^1.0.2",
+    "request": "^2.69.0",
     "selenium-grid-status": "^0.2.0",
     "selenium-webdriver": "^2.48.2",
+    "tmp": "0.0.28",
     "underscore": "^1.8.3"
   }
 }


### PR DESCRIPTION
Plumb an option through juttle-engine to override the index.html
that's served from the juttle-viewer router.