### PR TITLE
Fix browser command with non-default root path.

### DIFF
--- a/bin/juttle-engine
+++ b/bin/juttle-engine
@@ -6,12 +6,6 @@ var _ = require('underscore');
 var minimist = require('minimist');
 var engine = require('..');
 
-var defaults = {
-    'port': 8080,
-    'root': '/',
-    'log-level': 'info'
-};
-
 var possible_opts = {
     p: 'port',
     r: 'root',
@@ -42,8 +36,6 @@ function usage() {
 }
 
 var opts = minimist(process.argv.slice(2));
-
-_.defaults(opts, defaults);
 
 // Expand any single-letter option to its full-length equalivent.
 _.each(possible_opts, function(opt, short) {

--- a/bin/juttle-engine-client
+++ b/bin/juttle-engine-client
@@ -14,6 +14,7 @@ var open = require('open');
 var chokidar = require('chokidar');
 var fs = require('fs');
 var crypto = require('crypto');
+var rp = require('request-promise');
 
 function push_file(filename, topic) {
 
@@ -74,7 +75,7 @@ function get_file_hash(path) {
 
 function push_path(opts) {
     if (opts.path !== undefined) {
-        push_file(path.resolve(opts.path), opts.topic)
+        push_file(opts.path, opts.topic)
             .then(function() {
                 console.log(`==> View program at: http://${opts['juttle-engine']}/?rendezvous=${opts.topic}`);
             });
@@ -85,21 +86,20 @@ function push_path(opts) {
 
 function watch_path(opts) {
     if (opts.path !== undefined) {
-        var watchPath = path.resolve(opts.path);
-        var last_hash = get_file_hash(watchPath);
+        var last_hash = get_file_hash(opts.path);
 
-        push_file(watchPath, opts.topic)
+        push_file(opts.path, opts.topic)
             .then(function() {
                 console.log(`==> View program at: http://${opts['juttle-engine']}/?rendezvous=${opts.topic}`);
             });
 
         console.log(`Watching file ${opts.path} for changes:`);
 
-        chokidar.watch(watchPath).on('change', function(path) {
-            var hash = get_file_hash(watchPath);
+        chokidar.watch(opts.path).on('change', function(path) {
+            var hash = get_file_hash(opts.path);
 
             if (hash !== last_hash) {
-                push_file(watchPath, opts.topic);
+                push_file(opts.path, opts.topic);
             }
 
             last_hash = hash;
@@ -109,11 +109,39 @@ function watch_path(opts) {
     }
 }
 
+// Given a complete path, which reflects a path on the local
+// filesystem, figure out the right path suffix to use relative to the
+// juttle-service's root path. Returns a promise that resolves with
+// the correct path suffix on or rejects if the local path and the
+// service's root path don't share a prefix.
+function reconcile_path(juttle_engine, local_path) {
+    let idx;
+
+    return rp(`http://${juttle_engine}/api/v0/config-info/`)
+    .then(function(body) {
+        return JSON.parse(body);
+    })
+    .then(function(config) {
+        if (!_.has(config, 'root')) {
+            throw new Error('Server has no configured root directory');
+        }
+        // The root directory must be a prefix of the local path.
+        idx = local_path.indexOf(config.root);
+        if (idx !== 0) {
+            throw new Error(`Local path (${local_path}) is not a path below server root path (${config.root})`);
+        } else {
+            let relative_to_root = local_path.substring(config.root.length);
+            return relative_to_root;
+        }
+    });
+}
+
 function browser(opts) {
     if (opts.path) {
-        var absPath = path.resolve(opts.path);
-        open(`http://${opts['juttle-engine']}/?path=${absPath}`);
-
+        reconcile_path(opts['juttle-engine'], opts.path)
+        .then(function(rec_path) {
+            open(`http://${opts['juttle-engine']}/?path=${rec_path}`);
+        });
     } else {
         client.usage();
     }
@@ -168,6 +196,11 @@ _.defaults(opts, defaults);
 if (opts.help ||
     opts._.length !== 1) {
     client.usage();
+}
+
+// Resolve any path argument now so it doesn't have to be resolved later
+if (_.has(opts, 'path')) {
+    opts.path = path.resolve(opts.path);
 }
 
 client.command(opts['juttle-engine'], opts, command);

--- a/lib/juttle-engine.js
+++ b/lib/juttle-engine.js
@@ -17,33 +17,34 @@ const JUTTLE_ENGINE_VERSION = require('../package.json').version;
 JuttleService.version.addComponent('juttle-engine', JUTTLE_ENGINE_VERSION);
 
 function run(opts, ready) {
-    logSetup(_.defaults(opts, {'log-default-output': '/var/log/juttle-engine.log'}));
-    var logger = getLogger('juttle-engine')
-    var bundle_notifier = new BundleNotifier();
-
-    if (opts.daemonize) {
-        daemonize();
+    // If no port was provided on the command line, use a default port
+    // of 8080.
+    if (! _.has(opts, 'port')) {
+        opts.port = 8080;
     }
 
-    logger.debug('initializing with options', opts);
+    let config = service.configure(opts);
 
-    var service_opts = {
-        root_directory: opts.root,
-        config_path: opts.config
-    };
+    logSetup(config);
+    var logger = getLogger('juttle-engine');
+    var bundle_notifier = new BundleNotifier();
 
-    service.configure(service_opts);
+    logger.debug('service configuration', config);
+
+    if (config.daemonize) {
+        daemonize();
+    }
 
     app = express();
     app.disable('x-powered-by');
 
-    service.addRoutes(app, service_opts);
+    service.addRoutes(app, config, opts['config']);
 
     let viewerOpts = {
         indexPath: opts['index-path']
     };
-    if (opts.host) {
-        viewerOpts.juttleServiceHost = opts.host + ':' + opts.port;
+    if (config.host) {
+        viewerOpts.juttleServiceHost = config.host + ':' + config.port;
     }
     logger.debug('configuring juttle-viewer with', viewerOpts);
     app.use(viewer(viewerOpts));
@@ -54,10 +55,10 @@ function run(opts, ready) {
         bundle_notifier.add_endpoint_to_topic(ep, req.params.topic);
     });
 
-    var listenAddr = opts.host || '0.0.0.0';
-    server = app.listen(opts.port, listenAddr, () => {
-        logger.info('Juttle engine listening at http://' + listenAddr + ':' + opts.port
-                    + ' with root directory: ' + opts.root);
+    var listenAddr = config.host || '0.0.0.0';
+    server = app.listen(config.port, listenAddr, () => {
+        logger.info('Juttle engine listening at http://' + listenAddr + ':' + config.port
+                    + ' with root directory: ' + config.root);
         ready && ready();
     });
 }

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "juttle-viewer": "^0.2.0",
     "minimist": "^1.2.0",
     "open": "^0.0.5",
+    "request-promise": "^2.0.0",
     "underscore": "^1.8.3",
     "ws": "^0.4.31"
   },

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "juttle-mysql-adapter": "^0.5.0",
     "juttle-opentsdb-adapter": "^0.2.0",
     "juttle-postgres-adapter": "^0.5.0",
-    "juttle-service": "^0.3.0",
+    "juttle-service": "^0.4.0-rc.0",
     "juttle-sqlite-adapter": "^0.5.0",
     "juttle-twitter-adapter": "^0.3.0",
     "juttle-viewer": "^0.2.0",

--- a/test/juttle-engine.spec.js
+++ b/test/juttle-engine.spec.js
@@ -15,7 +15,8 @@ describe('Juttle Engine Tests', function() {
 
                 engine.run({
                     port: freePort,
-                    root: __dirname
+                    root: __dirname,
+                    host: 'localhost'
                 });
             });
     });


### PR DESCRIPTION
Make the browser command easier to use when run against a
juttle-engine/juttle-service with a root path other than /. Do this by
fetching the server's root directory and comparing that to the path
provided in the --path argument. If the root directory isn't a prefix
of the --path argument, throw an error. Otherwise, take just the part
not covered by the --root argument and use that as the ?path= cgi
param in the url.

In juttle-engine-client, also fully resolve the path immediately
instead of several times in the function for each command.

Also update juttle-engine to rely on juttle-service's built-in
defaults with juttle-config.js and command-line overrides. This
simplifies the initialization steps a bit.

These changes caused the test coverage numbers to dip slightly below
the thresholds, so provide some additional options when creating the
engine to cover one additional branch, which got the coverage numbers
up again.

This PR depends on changes in juttle-service (https://github.com/juttle/juttle-service/pull/67). I can wait to merge this until we're ready to push a new juttle-service, or do an early juttle-service release (bumping the minor number), and update package.json for juttle-engine to depend on it.

@demmer @go-oleg @VladVega 