### PR TITLE
Fixes to demo containers and juttle examples

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ Examples                               | Special instructions
 If you wish to run all available examples, this command will start all necessary docker containers:
 
 ```
-docker-compose -f dc-juttle-engine.yml -f elastic-newstracker/dc-elastic.yml -f cadvisor-influx/dc-cadvisor-influx.yml -f postgres-diskstats/dc-postgres.yml -f github-tutorial/dc-elastic.yml up
+docker-compose -f dc-juttle-engine.yml -f elastic-newstracker/dc-elastic.yml -f cadvisor-influx/dc-cadvisor-influx.yml -f github-tutorial/dc-elastic.yml -f postgres-diskstats/dc-postgres.yml up
 ```
 
 If that worked correctly, you should be able to visit this URL in your browser (if running via docker-machine, replace ``localhost`` with IP of the machine):

--- a/examples/elastic-newstracker/dc-elastic.yml
+++ b/examples/elastic-newstracker/dc-elastic.yml
@@ -1,7 +1,7 @@
 elastic_news_data:
    image: juttle/elastic_news_data
 
-elasticsearch:
+elasticsearch-news:
   container_name: examples_elasticsearch-news_1
   image: elasticsearch:2.1.1
   volumes_from:
@@ -11,6 +11,6 @@ elasticsearch:
 
 juttle-engine:
   links:
-    - elasticsearch
+    - elasticsearch-news
   external_links:
     - examples_elasticsearch-news_1

--- a/examples/elastic-newstracker/index.juttle
+++ b/examples/elastic-newstracker/index.juttle
@@ -9,8 +9,9 @@ emit
   add_juttle -name "search_ui" -description "Show daily counts of articles matching a search term";
   add_juttle -name "emotional_temp" -description "Show the emotional temperature for key phrases for each day";
   add_juttle -name "top_linked_pages" -description "Show the 10 most popular (most linked-to) pages";
-  add_juttle -name "top_linked_pages_write_rollup" -description "Find the most popular pages and save results to elasticsearch";
-  add_juttle -name "top_linked_pages_read_rollup" -description "Show the 10 most popular pages using results from elasticsearch"
+// temporarily hidden due to https://github.com/juttle/juttle-elastic-adapter/issues/126
+//  add_juttle -name "top_linked_pages_write_rollup" -description "Find the most popular pages and save results to elasticsearch";
+//  add_juttle -name "top_linked_pages_read_rollup" -description "Show the 10 most popular pages using results from elasticsearch"
 )
 | keep program, description
 | view table -title 'Demo Juttle Programs for Elasticsearch' -markdownFields [ 'program' ]

--- a/examples/elastic-newstracker/top_linked_pages.juttle
+++ b/examples/elastic-newstracker/top_linked_pages.juttle
@@ -1,5 +1,7 @@
-read elastic -id 'news' -from :2009-04-01: -to :2009-05-01: linkout != null tag != 'rollup_linkout'
-| reduce count() by 'linkout.raw'
+read elastic -id 'news' -from :2009-04-01: -to :2009-05-01:
+// temporarily unoptimized due to https://github.com/juttle/juttle-elastic-adapter/issues/126
+| filter linkout != null AND tag != 'rollup_linkout'
+| reduce count() by linkout
 | sort count -desc
 | head 10
 | view table -title 'Most popular pages, sample from April 2009'

--- a/examples/github-tutorial/dc-elastic.yml
+++ b/examples/github-tutorial/dc-elastic.yml
@@ -1,7 +1,7 @@
 elastic_github_data:
   image: juttle/elastic_github_data
 
-elasticsearch:
+elasticsearch-github:
   container_name: examples_elasticsearch-github_1
   image: elasticsearch:2.1.1
   volumes_from:
@@ -11,7 +11,7 @@ elasticsearch:
 
 juttle-engine:
   links:
-    - elasticsearch
+    - elasticsearch-github
   external_links:
     - examples_elasticsearch-github_1
   volumes:

--- a/examples/postgres-diskstats/throughput.juttle
+++ b/examples/postgres-diskstats/throughput.juttle
@@ -15,7 +15,8 @@ function round(number, precision) {
 )
 | join host
 |(
-  reduce value = avg(value) by diskmodel
+  unbatch // to make the downstream reduce apply in aggregate instead of per hour
+  | reduce value = avg(value) by diskmodel
   | sort value -desc
   | filter value != 0
   | view barchart -title 'Average hourly throughput by disk model, GB' -categoryField 'diskmodel' -row 0;


### PR DESCRIPTION
@mstemm this is what's needed to release the new juttle-engine and deploy to demo.juttle.io:
1) made names of elastic containers unique
2) dc-postgres.yml must be last in the docker-compose command, for unknown reasons
3) worked around an elastic-adapter bug in the news demo
4) worked around a change in our batch semantics in the postgres demo
Verified locally that with this, all examples work.