### PR TITLE
Adding links from example README to demo.juttle.io

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -6,18 +6,20 @@ The README files and juttle programs below this directory show different example
 
 To make it easy to download and run these programs, the instructions rely on docker and docker compose to create a juttle-engine instance linked to a variety of dependent backends. The linkage is done via juttle adapters.
 
+The same examples are deployed on the demo system [demo.juttle.io](http://demo.juttle.io/index.html).
+
 # tl;dr
 
-Examples                               | Special instructions
--------------------------------------- | --------------------
-[core-juttle](core-juttle/README.md)   | No special configuration; examples using http will need network connectivity
-[twitter-race](twitter-race/README.md) | To read from a twitter stream, you need to configure credentials in ``juttle-config.json`` file, see [README](twitter-race/README.md)
-[elastic-newstracker](elastic-newstracker/README.md) | To read from elasticsearch, this example needs to start additional docker containers, supply its yml file to ``docker-compose``
-[gmail](gmail/README.md) | To read from/write to gmail, you need to configure credentials in ``juttle-config.json`` file, see [README](gmail/README.md)
-[postgres-diskstats](postgres-diskstats/README.md) | Supply the yml file to ``docker-compose`` to start additional containers to read from PostgreSQL
-[cadvisor-influx](cadvisor-influx/README.md) | Supply the yml file to ``docker-compose`` to start additional containers to read from InfluxDB
-[aws-cloudwatch](aws-cloudwatch/README.md) | To read from AWS/Cloudwatch, you need to configure credentials in ``juttle-config.json``, see [README](aws-cloudwatch/README.md)
-[github-tutorial](github-tutorial/README.md) | To read from elasticsearch, the tutorial needs to start additional docker container, supply its yml file to ``docker-compose``
+Examples                               | Demo | Special instructions
+-------------------------------------- | ---- | --------------------
+[core-juttle](core-juttle/README.md)   | [demo-1](http://demo.juttle.io/?path=/examples/core-juttle/index.juttle) | No special configuration; examples using http will need network connectivity
+[twitter-race](twitter-race/README.md) | [demo-2](http://demo.juttle.io/?path=/examples/twitter-race/twitter.juttle) | To read from a twitter stream, you need to configure credentials in ``juttle-config.json`` file, see [README](twitter-race/README.md)
+[elastic-newstracker](elastic-newstracker/README.md) | [demo-3](http://demo.juttle.io/?path=/examples/elastic-newstracker/index.juttle) | To read from elasticsearch, this example needs to start additional docker containers, supply its yml file to ``docker-compose``
+[gmail](gmail/README.md) | [demo-4](http://demo.juttle.io/?path=/examples/gmail/index.juttle) | To read from/write to gmail, you need to configure credentials in ``juttle-config.json`` file, see [README](gmail/README.md)
+[postgres-diskstats](postgres-diskstats/README.md) | [demo-5](http://demo.juttle.io/?path=/examples/postgres-diskstats/throughput.juttle) | Supply the yml file to ``docker-compose`` to start additional containers to read from PostgreSQL
+[cadvisor-influx](cadvisor-influx/README.md) | [demo-6](http://demo.juttle.io/?path=/examples/cadvisor-influx/cadvisor-dashboard.juttle) | Supply the yml file to ``docker-compose`` to start additional containers to read from InfluxDB
+[aws-cloudwatch](aws-cloudwatch/README.md) | [demo-7](http://demo.juttle.io/?path=/examples/aws-cloudwatch/index.juttle) | To read from AWS/Cloudwatch, you need to configure credentials in ``juttle-config.json``, see [README](aws-cloudwatch/README.md)
+[github-tutorial](github-tutorial/README.md) | [demo-8](http://demo.juttle.io/?path=/examples/github-tutorial/index.juttle) | To read from elasticsearch, the tutorial needs to start additional docker container, supply its yml file to ``docker-compose``
 
 If you wish to run all available examples, this command will start all necessary docker containers:
 

--- a/examples/aws-cloudwatch/README.md
+++ b/examples/aws-cloudwatch/README.md
@@ -1,5 +1,11 @@
 # AWS/Cloudwatch
 
+# Setup
+
+This set of Juttle programs provides a dashboard of analytics from AWS and Cloudwatch data (which require configuring juttle adapters with your AWS credentials).
+
+You can view this example on the demo system [demo.juttle.io](http://demo.juttle.io/?path=/examples/aws-cloudwatch/index.juttle), or run it on your own using docker (see the parent [README](../README.md)).
+
 ## Additional docker-compose configuration
 
 The aws adapter by itself does not need any additional docker-compose

--- a/examples/cadvisor-influx/README.md
+++ b/examples/cadvisor-influx/README.md
@@ -6,6 +6,8 @@ This example demonstrates using Juttle with an InfluxDB backend via the [influx 
 
 Our Juttle program will then read the stats from InfluxDB backend and render visualizations of the container activity in the juttle-engine environment. Since this demo will have 3 docker containers running (influxdb, cadvisor and juttle-engine), we will monitor statistics from these three, as well as any other containers that happen to be running on the system.
 
+You can view this example on the demo system [demo.juttle.io](http://demo.juttle.io/?path=/examples/cadvisor-influx/cadvisor-dashboard.juttle), or run it on your own using docker (see the parent [README](../README.md)).
+
 ## tl;dr
 
 Run this from the parent `examples` dir (details in the parent [README.md](../README.md)):

--- a/examples/core-juttle/README.md
+++ b/examples/core-juttle/README.md
@@ -6,6 +6,8 @@ These examples use only built-in Juttle processors and adapters.  All
 you need to run these examples is to install juttle-engine and run
 juttle-engine, as described in the parent directory.
 
+You can view these examples on the demo system [demo.juttle.io](http://demo.juttle.io/?path=/examples/core-juttle/index.juttle), or run them on your own using docker (see the parent [README](../README.md)).
+
 ## Additional docker-compose configuration
 
 None needed.

--- a/examples/elastic-newstracker/README.md
+++ b/examples/elastic-newstracker/README.md
@@ -4,6 +4,8 @@
 
 This example loads a data set of Internet news snippets from April 2009, collected by Memetracker (see [data source](#data-source)), into ElasticSearch, then uses Juttle with the elasticsearch adapter to read this data, search the news, compute aggregations, and visualize in the browser.
 
+You can view this example on the demo system [demo.juttle.io](http://demo.juttle.io/?path=/examples/elastic-newstracker/index.juttle), or run it on your own using docker (see the parent [README](../README.md)).
+
 ## Additional docker-compose configuration
 
 [dc-elastic.yml](./dc-elastic.yml) in the current directory adds the following containers:

--- a/examples/github-tutorial/README.md
+++ b/examples/github-tutorial/README.md
@@ -4,6 +4,8 @@
 
 This set of example Juttle programs goes with the [Juttle Tutorial](http://juttle.github.io/juttle/concepts/juttle_tutorial/) targeting new developers. Second part of the tutorial uses a 6-month GitHub repo activity dataset loaded into Elasticsearch (size 29MB, 216158 records). This docker container provides ES with preloaded data.
 
+You can view these tutorial examples on the demo system [demo.juttle.io](http://demo.juttle.io/?path=/examples/github-tutorial/index.juttle), or run them on your own using docker (see the parent [README](../README.md)).
+
 ## Additional docker-compose configuration
 
 [dc-elastic.yml](./dc-elastic.yml) in the current directory adds the following containers:

--- a/examples/gmail/README.md
+++ b/examples/gmail/README.md
@@ -2,6 +2,8 @@
 
 These examples show ways to read messages from a gmail account and categorize the messages as well as writing the results of programs back to gmail by sending messages.
 
+You can view these examples on the demo system [demo.juttle.io](http://demo.juttle.io/?path=/examples/gmail/index.juttle), or run them on your own using docker (see the parent [README](../README.md)).
+
 A [detailed walkthrough](https://github.com/juttle/juttle-gmail-adapter/blob/master/docs/adapter_impl_notes.md) of the adapter implementation is available if you want to use it as a basis for writing your own adapters.
 
 ## Additional docker-compose configuration

--- a/examples/nginx_logs/README.md
+++ b/examples/nginx_logs/README.md
@@ -1,10 +1,13 @@
 # Example programs using nginx and elasticsearch
 
 ## Description
+
 The programs below this directory are mostly for internal use and
 can't be used on their own in an isolated docker-compose environment,
 so they're aren't described in the overall examples README. However,
 here's a quick description of how they work.
+
+You can view these examples on the demo system (link) [demo.juttle.io](http://demo.juttle.io/?path=/examples/nginx_logs/nginx-elastic.juttle).
 
 ## Additional docker-compose configuration
 

--- a/examples/postgres-diskstats/README.md
+++ b/examples/postgres-diskstats/README.md
@@ -10,6 +10,8 @@ this metadata has no timestamps and simply maps hosts to regions, subregions, po
 While we could ingest this data into another Posgres table, in this example we leave it in a file,
 to showcase joining data from different sources in a Juttle program.
 
+You can view this example on the demo system [demo.juttle.io](http://demo.juttle.io/?path=/examples/postgres-diskstats/throughput.juttle), or run it on your own using docker (see the parent [README](../README.md)).
+
 ## tl;dr
 
 Run this from the parent `examples` dir (details in the parent [README.md](../README.md)):

--- a/examples/twitter-race/README.md
+++ b/examples/twitter-race/README.md
@@ -4,6 +4,8 @@ This example shows reading from a live stream of tweets using the [twitter adapt
 The user inputs 2 search terms, juttle parses the incoming tweets to find matches, and displays match count as live-updating tiles and a timechart,
 to visually compare popularity of the requested terms.
 
+You can view this example on the demo system [demo.juttle.io](http://demo.juttle.io/?path=/examples/twitter-race/twitter.juttle), or run it on your own using docker (see the parent [README](../README.md)).
+
 ## Additional docker-compose configuration
 
 None needed.


### PR DESCRIPTION
@mstemm - added links for better discovery of demo.juttle.io examples.
I also intend to add the same links from each adapter's README.