### PR TITLE
Wait for juttle-engine to start in each unit test.

### DIFF
--- a/test/juttle-engine.spec.js
+++ b/test/juttle-engine.spec.js
@@ -4,6 +4,9 @@ var engine = require('../lib/juttle-engine');
 var WebSocket = require('ws');
 var Promise = require('bluebird');
 var findFreePort = Promise.promisify(require('find-free-port'));
+var retry = require('bluebird-retry');
+var chakram = require('chakram');
+var ckexpect = chakram.expect;
 
 describe('Juttle Engine Tests', function() {
     var juttleHostPort;
@@ -17,6 +20,11 @@ describe('Juttle Engine Tests', function() {
                     port: freePort,
                     root: __dirname,
                     host: 'localhost'
+                });
+            }).then(() => {
+                return retry(function() {
+                    var response = chakram.get(juttleHostPort + '/api/v0/version-info');
+                    ckexpect(response).to.have.status(200);
                 });
             });
     });


### PR DESCRIPTION
While running this locally, I noticed races where juttle-engine would
be started but the http server wasn't accepting connections yet,
leading to errors like:

Error: connect ECONNREFUSED 127.0.0.1:10000
    at Object.exports._errnoException (util.js:874:11)
    at exports._exceptionWithHostPort (util.js:897:20)
    at TCPConnectWrap.afterConnect [as oncomplete] (net.js:1063:14)

Fix this by waiting until a client can fetch /api/v0/version-info and
get an 200. Use bluebird-retry to retry the fetch.

@demmer @go-oleg