### PR TITLE
remove adapter tests from regular `gulp test/test-coverage` run

### DIFF
--- a/gulpfile.js
+++ b/gulpfile.js
@@ -47,6 +47,7 @@ function gulp_test() {
         tests.push('!test/app/**/*.spec.js');
         tests.push('!test/npm/**/*.spec.js');
         tests.push('!test/examples/**/*.spec.js');
+        tests.push('!test/adapters/**/*.spec.js');
         timeout = 20000; // 20s, test timeout
         slow = 15000;    // 15s, slow warning
     } else {


### PR DESCRIPTION
we shouldn't be running adapter tests when not specifying the `--sys` option
