### PR TITLE
npm install quietly when building docker image.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,7 @@ MAINTAINER Mark Stemm (mstemm@jut.io)
 RUN mkdir -p /opt/juttle-engine
 WORKDIR /opt/juttle-engine
 ADD package.json package.json
-RUN npm install
+RUN npm install --quiet
 COPY . .
 
 RUN mkdir -p /opt/juttle-engine/juttles


### PR DESCRIPTION
When building the local docker image used to run some system tests,
run npm install with the --quiet flag. Otherwise, the travis log fills
up with full details of the npm install and you can't see any actual
test results.

@rlgomes @demmer @go-oleg