### PR TITLE
Add module paths for example programs.

### DIFF
--- a/docker/images/juttle-engine/Dockerfile
+++ b/docker/images/juttle-engine/Dockerfile
@@ -11,4 +11,6 @@ COPY example-docker-files /opt/juttle-engine/juttles/examples/
 
 EXPOSE 8080
 
+ENV JUTTLE_MODULE_PATH /opt/juttle-engine/juttles:/opt/juttle-engine/examples:/opt/juttle-engine/examples/aws-cloudwatch
+
 CMD juttle-engine --root /opt/juttle-engine/juttles


### PR DESCRIPTION
Until https://github.com/juttle/juttle/issues/662 is fixed, add the
juttle root directory, the examples root directory, and the aws-examples
root directory to the set of module search paths so it's still possible
to run the amazon example programs without specifying relative paths in
import statements.

@demmer
